### PR TITLE
chore: align build system with other projects

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,105 +1,22 @@
-*/bin/**
+# macOS
+.DS_Store
+**/.DS_Store
 
-### VsCode ###
+### VSCode ###
 .vscode
 
-### Intellij ###
-# Covers JetBrains IDEs: IntelliJ, RubyMine, PhpStorm, AppCode, PyCharm, CLion, Android Studio and WebStorm
-# Reference: https://intellij-support.jetbrains.com/hc/en-us/articles/206544839
-.idea
-
-# User-specific stuff
-.idea/**/workspace.xml
-.idea/**/tasks.xml
-.idea/**/usage.statistics.xml
-.idea/**/dictionaries
-.idea/**/shelf
-
-# Generated files
-.idea/**/contentModel.xml
-
-# Sensitive or high-churn files
-.idea/**/dataSources/
-.idea/**/dataSources.ids
-.idea/**/dataSources.local.xml
-.idea/**/sqlDataSources.xml
-.idea/**/dynamic.xml
-.idea/**/uiDesigner.xml
-.idea/**/dbnavigator.xml
-
-# Gradle
-.idea/**/gradle.xml
-.idea/**/libraries
-
-# Gradle and Maven with auto-import
-# When using Gradle or Maven with auto-import, you should exclude module files,
-# since they will be recreated, and may cause churn.  Uncomment if using
-# auto-import.
-# .idea/modules.xml
-# .idea/*.iml
-# .idea/modules
-
-# CMake
-cmake-build-*/
-
-# Mongo Explorer plugin
-.idea/**/mongoSettings.xml
-
-# File-based project format
+### IntelliJ IDEA ###
+.idea/
+*.iml
+*.ipr
 *.iws
-
-# IntelliJ
 out/
 
-# mpeltonen/sbt-idea plugin
-.idea_modules/
-
-# JIRA plugin
-atlassian-ide-plugin.xml
-
-# Cursive Clojure plugin
-.idea/replstate.xml
-
-# Crashlytics plugin (for Android Studio and IntelliJ)
-com_crashlytics_export_strings.xml
-crashlytics.properties
-crashlytics-build.properties
-fabric.properties
-
-# Editor-based Rest Client
-.idea/httpRequests
-
-# Android studio 3.1+ serialized cache file
-.idea/caches/build_file_checksums.ser
-
-# JetBrains templates
-**___jb_tmp___
-
-### Intellij Patch ###
-# Comment Reason: https://github.com/joeblau/gitignore.io/issues/186#issuecomment-215987721
-
-# *.iml
-# modules.xml
-# .idea/misc.xml
-# *.ipr
-
-# Sonarlint plugin
-.idea/sonarlint
-
 ### Java ###
-# Compiled class file
 *.class
-
-# Log file
 *.log
-
-# BlueJ files
 *.ctxt
-
-# Mobile Tools for Java (J2ME)
 .mtj.tmp/
-
-# Package Files #
 *.jar
 *.war
 *.nar
@@ -107,54 +24,45 @@ fabric.properties
 *.zip
 *.tar.gz
 *.rar
-
-# virtual machine crash logs, see http://www.java.com/en/download/help/error_hotspot.xml
 hs_err_pid*
+
+# Avoid ignoring Gradle wrapper jar file
+!gradle-wrapper.jar
 
 ### Gradle ###
 .gradle
 build/
-
-# Ignore Gradle GUI config
+**/build/
 gradle-app.setting
-
-# Avoid ignoring Gradle wrapper jar file (.jar files are usually ignored)
-!gradle-wrapper.jar
-
-# Cache of project
 .gradletasknamecache
 
-# # Work around https://youtrack.jetbrains.com/issue/IDEA-116898
-# gradle/wrapper/gradle-wrapper.properties
-
-### Gradle Patch ###
-**/build/
-
-### macOS ###
-# General
-.DS_Store
-.AppleDouble
-.LSOverride
-
-# Icon must end with two \r
-Icon
-
-
-# Thumbnails
-._*
-
-# Files that might appear in the root of a volume
-.DocumentRevisions-V100
-.fseventsd
-.Spotlight-V100
-.TemporaryItems
-.Trashes
-.VolumeIcon.icns
-.com.apple.timemachine.donotpresent
-
-# Directories potentially created on remote AFP share
-.AppleDB
-.AppleDesktop
-Network Trash Folder
-Temporary Items
-.apdisk
+### Eclipse ###
+.metadata
+bin/
+tmp/
+*.tmp
+*.bak
+*.swp
+*~.nib
+local.properties
+.settings/
+.loadpath
+.recommenders
+.externalToolBuilders/
+*.launch
+*.pydevproject
+.cproject
+.autotools
+.factorypath
+.buildpath
+.target
+.tern-project
+.texlipse
+.springBeans
+.recommenders/
+.apt_generated/
+.apt_generated_test/
+.cache-main
+.scala_dependencies
+.worksheet
+.sts4-cache/

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -6,7 +6,7 @@ plugins {
     id("java")
 }
 
-val pluginVersion = "3.10.1"
+val pluginVersion: String by project
 
 allprojects {
     apply(plugin = "idea")

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,9 @@
+org.gradle.jvmargs=-Xmx2G
+org.gradle.parallel=true
+
+pluginVersion=3.10.1
+
 copyJar=true
-hacked_server_plugin_path=''
-velocity_plugin_path=''
-bungee_plugin_path=''
+hacked_server_plugin_path=
+velocity_plugin_path=
+bungee_plugin_path=

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,7 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https://services.gradle.org/distributions/gradle-8.1.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.14.3-bin.zip
+networkTimeout=10000
+validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists


### PR DESCRIPTION
- Upgrade Gradle wrapper from 8.1.1 to 8.14.3
- Move pluginVersion to gradle.properties
- Add parallel build and JVM args to gradle.properties
- Clean up and improve .gitignore

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Upgrade Gradle wrapper to 8.14.3, externalize pluginVersion and build flags to gradle.properties, and streamline .gitignore.
> 
> - **Build/Gradle**:
>   - Read `pluginVersion` from `gradle.properties` via delegated property in `build.gradle.kts`.
>   - Add `org.gradle.jvmargs` and enable parallel builds in `gradle.properties`.
> - **Gradle Wrapper**:
>   - Upgrade wrapper to `8.14.3` and enable `networkTimeout` and `validateDistributionUrl`.
> - **Configuration**:
>   - Normalize empty path properties in `gradle.properties` (remove quotes).
> - **Git Ignore**:
>   - Simplify and modernize `.gitignore` with focused entries for macOS, VSCode, IntelliJ, Eclipse, Java/Gradle; ensure `gradle-wrapper.jar` is not ignored.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit a6694fccd2f820ee8fbd051cdb171a342635a04f. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->