### PR TITLE
chore: bump version to 3.12.0

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,7 +1,7 @@
 org.gradle.jvmargs=-Xmx2G
 org.gradle.parallel=true
 
-pluginVersion=3.11.0
+pluginVersion=3.12.0
 
 copyJar=true
 hacked_server_plugin_path=


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Updates build configuration to use `pluginVersion=3.12.0`.
> 
> - Bumps `pluginVersion` from `3.11.0` to `3.12.0` in `gradle.properties`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 496966e423944df23d394444f10dd59d2dade4df. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->