### PR TITLE
chore: bump hopper-bukkit to 1.4.1

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -103,7 +103,7 @@ project(":hackedserver-spigot") {
         implementation("net.kyori:adventure-platform-bukkit:4.3.0")
         implementation("org.bstats:bstats-bukkit:3.1.0")
         // Hopper - Runtime dependency loader for auto-downloading ProtocolLib
-        implementation("md.thomas.hopper:hopper-bukkit:1.4.0")
+        implementation("md.thomas.hopper:hopper-bukkit:1.4.1")
     }
 }
 


### PR DESCRIPTION
Updates hopper-bukkit dependency to the latest patch version (1.4.1). This release contains bug fixes and is fully compatible with the existing code.

Build verification passed with no breaking changes detected.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Dependency update**
> 
> - Bumps `md.thomas.hopper:hopper-bukkit` in `hackedserver-spigot` from `1.4.0` to `1.4.1` (runtime dependency loader)
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 7691d283fad0f5452ca11530337ffa4fbaa78a5a. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->