### PR TITLE
chore: update PacketEvents to 2.11.1

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -100,7 +100,7 @@ project(":hackedserver-spigot") {
         // 1.21.11 support requires ProtocolLib dev snapshots (5.4.0 is not published as a stable release yet)
         compileOnly("com.comphenix.protocol:ProtocolLib:5.4.0-SNAPSHOT")
         // PacketEvents as alternative to ProtocolLib (better Arclight/hybrid server compatibility)
-        compileOnly("com.github.retrooper:packetevents-spigot:2.7.0")
+        compileOnly("com.github.retrooper:packetevents-spigot:2.11.1")
         compileOnly("net.kyori:adventure-text-minimessage:4.14.0")
         compileOnly("io.netty:netty-all:4.1.68.Final")
         compileOnly("dev.jorel:commandapi-bukkit-core:11.0.0")
@@ -141,7 +141,7 @@ project(":hackedserver-velocity") {
         compileOnly(project(path = ":hackedserver-core", configuration = "shadow"))
         compileOnly("com.velocitypowered:velocity-api:3.1.0")
         annotationProcessor("com.velocitypowered:velocity-api:3.1.0")
-        compileOnly("com.github.retrooper:packetevents-velocity:2.11.0")
+        compileOnly("com.github.retrooper:packetevents-velocity:2.11.1")
         implementation("org.bstats:bstats-velocity:3.1.0")
     }
 }


### PR DESCRIPTION
## Summary
- Update compile-time PacketEvents dependencies to 2.11.1
- hackedserver-spigot: 2.7.0 → 2.11.1
- hackedserver-velocity: 2.11.0 → 2.11.1

This aligns compile-time dependencies with the latest PacketEvents release for better API compatibility.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Updates PacketEvents compile-time dependencies to the latest 2.11.1 for better API alignment.
> 
> - `hackedserver-spigot`: `packetevents-spigot` 2.7.0 → 2.11.1
> - `hackedserver-velocity`: `packetevents-velocity` 2.11.0 → 2.11.1
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit ce980c68fec7a7b840868e7b35ad94db2e8b94fc. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->