### PR TITLE
Fix alert messages broadcasting to all players on Velocity

### DIFF
--- a/hackedserver-velocity/src/main/java/org/hackedserver/velocity/logs/Logs.java
+++ b/hackedserver-velocity/src/main/java/org/hackedserver/velocity/logs/Logs.java
@@ -27,7 +27,7 @@ public class Logs {
     }
 
     public static void logComponent(Component message) {
-        SERVER.sendMessage(message);
+        SERVER.getConsoleCommandSource().sendMessage(message);
     }
 
 }


### PR DESCRIPTION
`Logs.logComponent()` was calling `ProxyServer.sendMessage()` which broadcasts to all connected players instead of logging to console only
  - Fixed by using `getConsoleCommandSource().sendMessage()`  