### PR TITLE
fix: Velocity plugin startup injection error

### DIFF
--- a/hackedserver-velocity/src/main/java/org/hackedserver/velocity/HackedServerPlugin.java
+++ b/hackedserver-velocity/src/main/java/org/hackedserver/velocity/HackedServerPlugin.java
@@ -21,7 +21,7 @@ import org.hackedserver.velocity.listeners.CustomPayloadListener;
 import org.hackedserver.velocity.listeners.HackedPlayerListeners;
 import org.hackedserver.velocity.logs.Logs;
 
-import javax.inject.Inject;
+import com.google.inject.Inject;
 
 import java.io.File;
 import java.nio.file.Path;


### PR DESCRIPTION
## 🟠 Fix Velocity plugin startup injection error
- **Summary** - Fixed Guice injector not recognizing the constructor in HackedServerPlugin for Velocity
- **Description** - The plugin failed to load with "No injectable constructor" error because the @Inject annotation was using javax.inject.Inject instead of com.google.inject.Inject. Velocity's plugin loader uses Guice for dependency injection, so Guice's @Inject annotation is required.

- **Changes** - Changed import in `hackedserver-velocity/src/main/java/org/hackedserver/velocity/HackedServerPlugin.java:24` from `javax.inject.Inject` to `com.google.inject.Inject`