### PR TITLE
feat: Add Discord Join Webhook Feature

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -92,7 +92,7 @@ project(":hackedserver-core") {
         // Explicit ANTLR runtime dependency to ensure it gets shaded
         // xtomlj uses 4.7.2 which has ATN v3, conflicts with Arclight's ANTLR 4.13.1 (ATN v4)
         implementation("org.antlr:antlr4-runtime:4.7.2")
-        implementation("com.lunarclient:apollo-protos:0.0.5")
+        implementation("com.lunarclient:apollo-protos:0.0.6")
         // Geyser/Floodgate APIs for bedrock player detection (compile-only, loaded via class isolation)
         compileOnly("org.geysermc.geyser:api:2.4.2-SNAPSHOT")
         compileOnly("org.geysermc.floodgate:api:2.2.3-SNAPSHOT")

--- a/hackedserver-bungeecord/src/main/java/org/hackedserver/bungee/listeners/HackedPlayerListeners.java
+++ b/hackedserver-bungeecord/src/main/java/org/hackedserver/bungee/listeners/HackedPlayerListeners.java
@@ -17,7 +17,13 @@ import org.hackedserver.core.bedrock.BedrockDetector;
 import org.hackedserver.core.config.Action;
 import org.hackedserver.core.config.BedrockConfig;
 
+import org.hackedserver.core.utils.JoinWebhook;
+
+import java.util.concurrent.TimeUnit;
+
 public class HackedPlayerListeners implements Listener {
+
+    private static final long JOIN_WEBHOOK_DELAY_SECONDS = 1L;
 
     @EventHandler
     public void onPlayerJoin(LoginEvent event) {
@@ -28,6 +34,11 @@ public class HackedPlayerListeners implements Listener {
     public void onPostLogin(PostLoginEvent event) {
         ProxiedPlayer player = event.getPlayer();
         HackedPlayer hackedPlayer = HackedServer.getPlayer(player.getUniqueId());
+        
+        ProxyServer.getInstance().getScheduler().schedule(HackedServerPlugin.get(), () -> {
+            JoinWebhook.send(player.getName(), player.getUniqueId());
+        }, JOIN_WEBHOOK_DELAY_SECONDS, TimeUnit.SECONDS);
+
         if (hackedPlayer.hasPendingActions()) {
             hackedPlayer.executePendingActions();
         }

--- a/hackedserver-core/src/main/java/org/hackedserver/core/config/Config.java
+++ b/hackedserver-core/src/main/java/org/hackedserver/core/config/Config.java
@@ -8,7 +8,15 @@ public enum Config {
     DEBUG("settings.debug"),
     SKIP_DUPLICATES("settings.skip_duplicates"),
     AUTO_DOWNLOAD_DEPENDENCIES("settings.auto_download_dependencies"),
-    ACTION_DELAY_TICKS("settings.action_delay_ticks");
+    ACTION_DELAY_TICKS("settings.action_delay_ticks"),
+
+    JOIN_WEBHOOK_ENABLED("join_webhook.enabled"),
+    JOIN_WEBHOOK_URL("join_webhook.url"),
+    JOIN_WEBHOOK_CONTENT("join_webhook.content"),
+    JOIN_WEBHOOK_EMBED_TITLE("join_webhook.embed_title"),
+    JOIN_WEBHOOK_EMBED_DESCRIPTION("join_webhook.embed_description"),
+    JOIN_WEBHOOK_EMBED_COLOR("join_webhook.embed_color"),
+    JOIN_WEBHOOK_EMBED_FOOTER("join_webhook.embed_footer");
 
     private static TomlParseResult result;
 

--- a/hackedserver-core/src/main/java/org/hackedserver/core/utils/DiscordWebhook.java
+++ b/hackedserver-core/src/main/java/org/hackedserver/core/utils/DiscordWebhook.java
@@ -1,0 +1,89 @@
+package org.hackedserver.core.utils;
+
+import java.io.OutputStream;
+import java.net.HttpURLConnection;
+import java.net.URL;
+import java.nio.charset.StandardCharsets;
+
+public class DiscordWebhook {
+
+    public static void send(String webhookUrl, String content, String embedTitle, String embedDescription, int embedColor, String embedFooter) {
+        if (webhookUrl == null || webhookUrl.isEmpty()) {
+            return;
+        }
+
+        try {
+            URL url = new URL(webhookUrl);
+            HttpURLConnection connection = (HttpURLConnection) url.openConnection();
+            connection.setConnectTimeout(5000);
+            connection.setReadTimeout(5000);
+            connection.setRequestMethod("POST");
+            connection.setRequestProperty("Content-Type", "application/json");
+            connection.setRequestProperty("User-Agent", "HackedServer-Webhook");
+            connection.setDoOutput(true);
+
+            String jsonPayload = buildJsonPayload(content, embedTitle, embedDescription, embedColor, embedFooter);
+
+            try (OutputStream os = connection.getOutputStream()) {
+                byte[] input = jsonPayload.getBytes(StandardCharsets.UTF_8);
+                os.write(input, 0, input.length);
+            }
+
+            int responseCode = connection.getResponseCode();
+            if (responseCode >= 400) {
+                System.err.println("[HackedServer] Webhook request failed with status: " + responseCode);
+            }
+            connection.disconnect();
+        } catch (Exception e) {
+            e.printStackTrace();
+        }
+    }
+
+    private static String buildJsonPayload(String content, String title, String description, int color, String footer) {
+        StringBuilder json = new StringBuilder();
+        json.append("{");
+        
+        if (content != null && !content.isEmpty()) {
+            json.append("\"content\": \"").append(escapeJson(content)).append("\",");
+        }
+
+        json.append("\"embeds\": [{");
+        
+        boolean hasField = false;
+        if (title != null && !title.isEmpty()) {
+            json.append("\"title\": \"").append(escapeJson(title)).append("\"");
+            hasField = true;
+        }
+        
+        if (description != null && !description.isEmpty()) {
+            if (hasField) json.append(",");
+            json.append("\"description\": \"").append(escapeJson(description)).append("\"");
+            hasField = true;
+        }
+        
+        if (hasField) json.append(",");
+        json.append("\"color\": ").append(color);
+        hasField = true;
+        
+        if (footer != null && !footer.isEmpty()) {
+            if (hasField) json.append(",");
+            json.append("\"footer\": {\"text\": \"").append(escapeJson(footer)).append("\"}");
+        }
+        
+        json.append("}]");
+        json.append("}");
+        
+        return json.toString();
+    }
+
+    private static String escapeJson(String input) {
+        if (input == null) return "";
+        return input.replace("\\", "\\\\")
+                    .replace("\"", "\\\"")
+                    .replace("\b", "\\b")
+                    .replace("\f", "\\f")
+                    .replace("\n", "\\n")
+                    .replace("\r", "\\r")
+                    .replace("\t", "\\t");
+    }
+}

--- a/hackedserver-core/src/main/java/org/hackedserver/core/utils/JoinWebhook.java
+++ b/hackedserver-core/src/main/java/org/hackedserver/core/utils/JoinWebhook.java
@@ -1,0 +1,98 @@
+package org.hackedserver.core.utils;
+
+import org.hackedserver.core.HackedPlayer;
+import org.hackedserver.core.HackedServer;
+import org.hackedserver.core.config.Config;
+import org.hackedserver.core.forge.ForgeClientType;
+import org.hackedserver.core.forge.ForgeModInfo;
+import org.hackedserver.core.lunar.LunarModInfo;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.UUID;
+
+public class JoinWebhook {
+
+    public static void send(String playerName, UUID playerUuid) {
+        if (!Config.JOIN_WEBHOOK_ENABLED.toBool()) {
+            return;
+        }
+
+        String url = Config.JOIN_WEBHOOK_URL.getStringOrDefault("");
+        String content = replacePlaceholders(Config.JOIN_WEBHOOK_CONTENT.getStringOrDefault(""), playerName, playerUuid);
+        String title = replacePlaceholders(Config.JOIN_WEBHOOK_EMBED_TITLE.getStringOrDefault("Player Joined"), playerName, playerUuid);
+        String description = replacePlaceholders(Config.JOIN_WEBHOOK_EMBED_DESCRIPTION.getStringOrDefault("Player {player} has joined."), playerName, playerUuid);
+        int color = (int) Config.JOIN_WEBHOOK_EMBED_COLOR.toLong(65280);
+        String footer = replacePlaceholders(Config.JOIN_WEBHOOK_EMBED_FOOTER.getStringOrDefault("HackedServer"), playerName, playerUuid);
+
+        DiscordWebhook.send(url, content, title, description, color, footer);
+    }
+
+    private static String replacePlaceholders(String input, String playerName, UUID playerUuid) {
+        if (input == null) {
+            return "";
+        }
+        String safeName = playerName != null ? playerName : "Unknown";
+        String safeUuid = playerUuid != null ? playerUuid.toString() : "Unknown";
+        HackedPlayer hackedPlayer = playerUuid != null ? HackedServer.getPlayer(playerUuid) : null;
+        String client = getClientName(hackedPlayer);
+        String modlist = getModList(hackedPlayer);
+        return input.replace("{player}", safeName)
+                .replace("{uuid}", safeUuid)
+                .replace("{client}", client)
+                .replace("{modlist}", modlist);
+    }
+
+    private static String getClientName(HackedPlayer hackedPlayer) {
+        if (hackedPlayer == null) {
+            return "Unknown";
+        }
+        if (hackedPlayer.isBedrockDetected()) {
+            return "Bedrock";
+        }
+        if (hackedPlayer.hasLunarModsData()) {
+            return "Lunar Client";
+        }
+
+        ForgeClientType forgeClientType = hackedPlayer.getForgeClientType();
+        if (forgeClientType != null) {
+            return forgeClientType.getDisplayName();
+        }
+
+        return "Unknown";
+    }
+
+    private static String getModList(HackedPlayer hackedPlayer) {
+        if (hackedPlayer == null) {
+            return "Unknown";
+        }
+
+        List<String> mods = new ArrayList<>();
+        for (LunarModInfo mod : hackedPlayer.getLunarMods()) {
+            String displayName = mod.getDisplayName() != null && !mod.getDisplayName().isBlank()
+                    ? mod.getDisplayName()
+                    : mod.getId();
+            if (displayName == null || displayName.isBlank()) {
+                continue;
+            }
+            if (mod.getVersion() != null && !mod.getVersion().isBlank()) {
+                mods.add(displayName + " (" + mod.getVersion() + ")");
+            } else {
+                mods.add(displayName);
+            }
+        }
+        for (ForgeModInfo mod : hackedPlayer.getForgeMods()) {
+            mods.add(mod.toString());
+        }
+
+        if (!mods.isEmpty()) {
+            return String.join(", ", mods);
+        }
+
+        if (hackedPlayer.hasLunarModsData() || hackedPlayer.hasForgeModsData()) {
+            return "None";
+        }
+
+        return "Unknown";
+    }
+}

--- a/hackedserver-core/src/main/resources/config.toml
+++ b/hackedserver-core/src/main/resources/config.toml
@@ -15,5 +15,13 @@ auto_download_dependencies = true
 # Delay in ticks before executing actions after a check is triggered
 # This helps ensure the player is fully connected before kicks/commands are executed
 # Set to 0 for no delay, or increase if kicks fail on some server software (e.g., Purpur)
-# Can also be configured per-action in actions.toml
-action_delay_ticks = 20
+
+[join_webhook]
+enabled = false
+url = ""
+content = ""
+embed_title = "Player Joined"
+embed_description = "Player {player} has joined the server."
+embed_color = 65280
+embed_footer = "HackedServer"
+

--- a/hackedserver-spigot/src/main/java/org/hackedserver/spigot/listeners/HackedPlayerListeners.java
+++ b/hackedserver-spigot/src/main/java/org/hackedserver/spigot/listeners/HackedPlayerListeners.java
@@ -19,9 +19,13 @@ import org.hackedserver.spigot.commands.CommandsManager;
 import org.hackedserver.core.bedrock.BedrockDetector;
 import net.kyori.adventure.text.minimessage.tag.resolver.Placeholder;
 
+import org.hackedserver.core.utils.JoinWebhook;
+
 import java.util.Map;
 
 public class HackedPlayerListeners implements Listener {
+
+    private static final long JOIN_WEBHOOK_DELAY_TICKS = 20L;
 
     @EventHandler
     public void onPlayerPreLogin(AsyncPlayerPreLoginEvent event) {
@@ -32,6 +36,11 @@ public class HackedPlayerListeners implements Listener {
     public void onPlayerJoin(PlayerJoinEvent event) {
         Player player = event.getPlayer();
         HackedPlayer hackedPlayer = HackedServer.getPlayer(player.getUniqueId());
+
+        Bukkit.getScheduler().runTaskLaterAsynchronously(HackedServerPlugin.get(), () -> {
+            JoinWebhook.send(player.getName(), player.getUniqueId());
+        }, JOIN_WEBHOOK_DELAY_TICKS);
+
         if (hackedPlayer.hasPendingActions()) {
             // Execute pending actions after a short delay to ensure player is fully initialized
             // Use at least 1 tick to ensure the join event completes

--- a/hackedserver-velocity/src/main/java/org/hackedserver/velocity/HackedServerPlugin.java
+++ b/hackedserver-velocity/src/main/java/org/hackedserver/velocity/HackedServerPlugin.java
@@ -60,7 +60,7 @@ public class HackedServerPlugin {
 
     @Subscribe
     public void onProxyInitialization(ProxyInitializeEvent event) {
-        server.getEventManager().register(this, new HackedPlayerListeners(server));
+        server.getEventManager().register(this, new HackedPlayerListeners(server, this));
         PacketEvents.getAPI().getEventManager().registerListener(
                 new CustomPayloadListener(server), PacketListenerPriority.NORMAL);
         PacketEvents.getAPI().init();
@@ -86,7 +86,7 @@ public class HackedServerPlugin {
         commands.create();
 
         // Re-register event listeners
-        server.getEventManager().register(this, new HackedPlayerListeners(server));
+        server.getEventManager().register(this, new HackedPlayerListeners(server, this));
         PacketEvents.getAPI().getEventManager().registerListener(
                 new CustomPayloadListener(server), PacketListenerPriority.NORMAL);
     }

--- a/hackedserver-velocity/src/main/java/org/hackedserver/velocity/listeners/HackedPlayerListeners.java
+++ b/hackedserver-velocity/src/main/java/org/hackedserver/velocity/listeners/HackedPlayerListeners.java
@@ -15,12 +15,20 @@ import org.hackedserver.core.config.Action;
 import org.hackedserver.core.config.BedrockConfig;
 import org.hackedserver.velocity.logs.Logs;
 
+import org.hackedserver.core.utils.JoinWebhook;
+
+import java.time.Duration;
+
 public class HackedPlayerListeners {
 
-    private final ProxyServer server;
+    private static final Duration JOIN_WEBHOOK_DELAY = Duration.ofSeconds(1);
 
-    public HackedPlayerListeners(ProxyServer server) {
+    private final ProxyServer server;
+    private final Object plugin;
+
+    public HackedPlayerListeners(ProxyServer server, Object plugin) {
         this.server = server;
+        this.plugin = plugin;
     }
 
     @Subscribe
@@ -32,6 +40,11 @@ public class HackedPlayerListeners {
     public void onPostLogin(PostLoginEvent event) {
         Player player = event.getPlayer();
         HackedPlayer hackedPlayer = HackedServer.getPlayer(player.getUniqueId());
+
+        server.getScheduler().buildTask(plugin, () -> {
+            JoinWebhook.send(player.getUsername(), player.getUniqueId());
+        }).delay(JOIN_WEBHOOK_DELAY).schedule();
+
         if (hackedPlayer.hasPendingActions()) {
             hackedPlayer.executePendingActions();
         }


### PR DESCRIPTION
## 🟠 Add Discord Join Webhook Feature
- **Summary** - Added a Discord webhook feature that sends an embed when a player joins the server, including client and modlist information.
- **Description** - Implemented a new join webhook system that allows server owners to receive Discord notifications with player join details. The webhook includes placeholders for player name, UUID, client type (e.g., Lunar Client, Forge, Bedrock), and modlist. The webhook is sent asynchronously with a delay to ensure client detection data is populated. Also bumped Apollo version to fix a build issue.
- **Changes**
  - Updated `build.gradle.kts` - Bumped `apollo-protos` version to `0.0.6`
  - Created `hackedserver-core/src/main/java/org/hackedserver/core/utils/DiscordWebhook.java` - Utility to send Discord webhooks
  - Created `hackedserver-core/src/main/java/org/hackedserver/core/utils/JoinWebhook.java` - Handles webhook configuration and placeholders
  - Updated `hackedserver-core/src/main/resources/config.toml` - Added `[join_webhook]` configuration section
  - Updated `hackedserver-core/src/main/java/org/hackedserver/core/config/Config.java` - Added enum constants for webhook settings
  - Updated `hackedserver-spigot/src/main/java/org/hackedserver/spigot/listeners/HackedPlayerListeners.java` - Added delayed async webhook trigger (20 ticks)
  - Updated `hackedserver-bungeecord/src/main/java/org/hackedserver/bungee/listeners/HackedPlayerListeners.java` - Added delayed async webhook trigger (1 second)
  - Updated `hackedserver-velocity/src/main/java/org/hackedserver/velocity/listeners/HackedPlayerListeners.java` - Added delayed async webhook trigger (1 second)