### PR TITLE
feat: Meteor Client detection and brand spoofing

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -96,6 +96,8 @@ project(":hackedserver-core") {
         // Geyser/Floodgate APIs for bedrock player detection (compile-only, loaded via class isolation)
         compileOnly("org.geysermc.geyser:api:2.4.2-SNAPSHOT")
         compileOnly("org.geysermc.floodgate:api:2.2.3-SNAPSHOT")
+        // PacketEvents API for packet-level sign translation probing (proxy platforms)
+        compileOnly("com.github.retrooper:packetevents-api:2.11.1")
     }
 }
 
@@ -130,6 +132,7 @@ project(":hackedserver-bungeecord") {
         compileOnly("net.md-5:bungeecord-api:1.20-R0.2")
         compileOnly("net.kyori:adventure-text-minimessage:4.14.0")
         compileOnly(project(path = ":hackedserver-core", configuration = "shadow"))
+        compileOnly("com.github.retrooper:packetevents-bungeecord:2.11.1")
 
         implementation("net.kyori:adventure-platform-bungeecord:4.3.0")
         implementation("org.bstats:bstats-bungeecord:3.1.0")

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,7 +1,7 @@
 org.gradle.jvmargs=-Xmx2G
 org.gradle.parallel=true
 
-pluginVersion=3.17.1
+pluginVersion=3.17.2
 
 copyJar=true
 hacked_server_plugin_path=

--- a/hackedserver-bungeecord/src/main/java/org/hackedserver/bungee/HackedServerPlugin.java
+++ b/hackedserver-bungeecord/src/main/java/org/hackedserver/bungee/HackedServerPlugin.java
@@ -54,6 +54,7 @@ public class HackedServerPlugin extends Plugin {
         }
 
         PluginManager pluginManager = this.getProxy().getPluginManager();
+        pluginManager.registerListener(this, new HackedPlayerListeners(this::getSignProber));
         pluginManager.registerListener(this, new CustomPayloadListener());
         pluginManager.registerCommand(this, new CommandsManager(this.getProxy(), getDataFolder()));
         this.getProxy().registerChannel(LunarApolloHandshakeParser.CHANNEL);
@@ -63,7 +64,6 @@ public class HackedServerPlugin extends Plugin {
             signProber = new PacketSignProber((uuid, playerName, checkName, actions) -> {
                 executeProbeActions(uuid, playerName, checkName, actions);
             });
-            pluginManager.registerListener(this, new HackedPlayerListeners(signProber));
             signProber.register();
             PacketEvents.getAPI().init();
         } catch (Throwable e) {
@@ -88,6 +88,10 @@ public class HackedServerPlugin extends Plugin {
 
     public static HackedServerPlugin get() {
         return instance;
+    }
+
+    public PacketSignProber getSignProber() {
+        return signProber;
     }
 
     public BungeeAudiences getAudiences() {

--- a/hackedserver-bungeecord/src/main/java/org/hackedserver/bungee/HackedServerPlugin.java
+++ b/hackedserver-bungeecord/src/main/java/org/hackedserver/bungee/HackedServerPlugin.java
@@ -38,6 +38,7 @@ public class HackedServerPlugin extends Plugin {
 
         // Initialize PacketEvents for sign translation probing
         PacketEvents.setAPI(BungeePacketEventsBuilder.build(this));
+        PacketEvents.getAPI().load();
 
         // Create sign prober with BungeeCord action executor
         signProber = new PacketSignProber((uuid, playerName, checkName, actions) -> {
@@ -98,7 +99,7 @@ public class HackedServerPlugin extends Plugin {
                 continue;
             }
             if (player.hasPermission("hackedserver.bypass")) {
-                return;
+                continue;
             }
 
             for (String command : action.getConsoleCommands()) {

--- a/hackedserver-bungeecord/src/main/java/org/hackedserver/bungee/HackedServerPlugin.java
+++ b/hackedserver-bungeecord/src/main/java/org/hackedserver/bungee/HackedServerPlugin.java
@@ -45,22 +45,34 @@ public class HackedServerPlugin extends Plugin {
             return;
         }
 
-        PacketEvents.setAPI(BungeePacketEventsBuilder.build(this));
-        PacketEvents.getAPI().load();
-
-        // Create sign prober with BungeeCord action executor
-        signProber = new PacketSignProber((uuid, playerName, checkName, actions) -> {
-            executeProbeActions(uuid, playerName, checkName, actions);
-        });
+        try {
+            PacketEvents.setAPI(BungeePacketEventsBuilder.build(this));
+            PacketEvents.getAPI().load();
+        } catch (Throwable e) {
+            getLogger().severe("Failed to initialize PacketEvents. HackedServer will not function: " + e.getMessage());
+            return;
+        }
 
         PluginManager pluginManager = this.getProxy().getPluginManager();
-        pluginManager.registerListener(this, new HackedPlayerListeners(signProber));
         pluginManager.registerListener(this, new CustomPayloadListener());
         pluginManager.registerCommand(this, new CommandsManager(this.getProxy(), getDataFolder()));
         this.getProxy().registerChannel(LunarApolloHandshakeParser.CHANNEL);
 
-        signProber.register();
-        PacketEvents.getAPI().init();
+        try {
+            // Create sign prober with BungeeCord action executor
+            signProber = new PacketSignProber((uuid, playerName, checkName, actions) -> {
+                executeProbeActions(uuid, playerName, checkName, actions);
+            });
+            pluginManager.registerListener(this, new HackedPlayerListeners(signProber));
+            signProber.register();
+            PacketEvents.getAPI().init();
+        } catch (Throwable e) {
+            getLogger().severe("Failed to register PacketEvents listeners. HackedServer will not function: " + e.getMessage());
+            if (signProber != null) {
+                signProber.unregister();
+                signProber = null;
+            }
+        }
     }
 
     @Override

--- a/hackedserver-bungeecord/src/main/java/org/hackedserver/bungee/HackedServerPlugin.java
+++ b/hackedserver-bungeecord/src/main/java/org/hackedserver/bungee/HackedServerPlugin.java
@@ -1,6 +1,12 @@
 package org.hackedserver.bungee;
 
+import com.github.retrooper.packetevents.PacketEvents;
+import io.github.retrooper.packetevents.bungee.factory.BungeePacketEventsBuilder;
 import net.kyori.adventure.platform.bungeecord.BungeeAudiences;
+import net.kyori.adventure.text.minimessage.tag.resolver.Placeholder;
+import net.kyori.adventure.text.minimessage.tag.resolver.TagResolver;
+import net.md_5.bungee.api.ProxyServer;
+import net.md_5.bungee.api.connection.ProxiedPlayer;
 import net.md_5.bungee.api.plugin.Plugin;
 import net.md_5.bungee.api.plugin.PluginManager;
 import org.hackedserver.bungee.commands.CommandsManager;
@@ -8,13 +14,19 @@ import org.hackedserver.bungee.listeners.CustomPayloadListener;
 import org.hackedserver.bungee.listeners.HackedPlayerListeners;
 import org.hackedserver.bungee.logs.Logs;
 import org.hackedserver.core.bedrock.BedrockDetector;
+import org.hackedserver.core.config.Action;
 import org.hackedserver.core.config.ConfigsManager;
 import org.hackedserver.core.lunar.LunarApolloHandshakeParser;
+import org.hackedserver.core.probing.PacketSignProber;
+
+import java.util.List;
+import java.util.UUID;
 
 public class HackedServerPlugin extends Plugin {
 
     private BungeeAudiences audiences;
     private static HackedServerPlugin instance;
+    private PacketSignProber signProber;
 
     @Override
     public void onEnable() {
@@ -23,15 +35,33 @@ public class HackedServerPlugin extends Plugin {
         Logs.onEnable(getLogger(), audiences);
         ConfigsManager.init(getDataFolder());
         BedrockDetector.initialize(getLogger());
+
+        // Initialize PacketEvents for sign translation probing
+        PacketEvents.setAPI(BungeePacketEventsBuilder.build(this));
+
+        // Create sign prober with BungeeCord action executor
+        signProber = new PacketSignProber((uuid, playerName, checkName, actions) -> {
+            executeProbeActions(uuid, playerName, checkName, actions);
+        });
+
         PluginManager pluginManager = this.getProxy().getPluginManager();
-        pluginManager.registerListener(this, new HackedPlayerListeners());
+        pluginManager.registerListener(this, new HackedPlayerListeners(signProber));
         pluginManager.registerListener(this, new CustomPayloadListener());
         pluginManager.registerCommand(this, new CommandsManager(this.getProxy(), getDataFolder()));
         this.getProxy().registerChannel(LunarApolloHandshakeParser.CHANNEL);
+
+        signProber.register();
+        PacketEvents.getAPI().init();
     }
 
     @Override
     public void onDisable() {
+        if (signProber != null) {
+            signProber.unregister();
+        }
+        if (PacketEvents.getAPI() != null) {
+            PacketEvents.getAPI().terminate();
+        }
         this.getProxy().unregisterChannel(LunarApolloHandshakeParser.CHANNEL);
     }
 
@@ -41,5 +71,48 @@ public class HackedServerPlugin extends Plugin {
 
     public BungeeAudiences getAudiences() {
         return audiences;
+    }
+
+    private void executeProbeActions(UUID uuid, String playerName, String checkName, List<Action> actions) {
+        if (actions == null || actions.isEmpty()) {
+            return;
+        }
+
+        TagResolver.Single[] templates = new TagResolver.Single[]{
+                Placeholder.unparsed("player", playerName),
+                Placeholder.parsed("name", checkName)
+        };
+
+        for (Action action : actions) {
+            if (action.hasAlert()) {
+                Logs.logComponent(action.getAlert(templates));
+                for (ProxiedPlayer admin : ProxyServer.getInstance().getPlayers()) {
+                    if (admin.hasPermission("hackedserver.alert")) {
+                        audiences.player(admin).sendMessage(action.getAlert(templates));
+                    }
+                }
+            }
+
+            ProxiedPlayer player = ProxyServer.getInstance().getPlayer(uuid);
+            if (player == null || !player.isConnected()) {
+                continue;
+            }
+            if (player.hasPermission("hackedserver.bypass")) {
+                return;
+            }
+
+            for (String command : action.getConsoleCommands()) {
+                ProxyServer.getInstance().getPluginManager().dispatchCommand(
+                        ProxyServer.getInstance().getConsole(),
+                        command.replace("<player>", playerName)
+                                .replace("<name>", checkName));
+            }
+            for (String command : action.getPlayerCommands()) {
+                ProxyServer.getInstance().getPluginManager().dispatchCommand(
+                        player,
+                        command.replace("<player>", playerName)
+                                .replace("<name>", checkName));
+            }
+        }
     }
 }

--- a/hackedserver-bungeecord/src/main/java/org/hackedserver/bungee/HackedServerPlugin.java
+++ b/hackedserver-bungeecord/src/main/java/org/hackedserver/bungee/HackedServerPlugin.java
@@ -37,6 +37,14 @@ public class HackedServerPlugin extends Plugin {
         BedrockDetector.initialize(getLogger());
 
         // Initialize PacketEvents for sign translation probing
+        try {
+            Class.forName("com.github.retrooper.packetevents.PacketEvents");
+        } catch (ClassNotFoundException e) {
+            getLogger().severe("PacketEvents is required but not installed! HackedServer will not function.");
+            getLogger().severe("Please install PacketEvents on your BungeeCord proxy.");
+            return;
+        }
+
         PacketEvents.setAPI(BungeePacketEventsBuilder.build(this));
         PacketEvents.getAPI().load();
 

--- a/hackedserver-bungeecord/src/main/java/org/hackedserver/bungee/listeners/CustomPayloadListener.java
+++ b/hackedserver-bungeecord/src/main/java/org/hackedserver/bungee/listeners/CustomPayloadListener.java
@@ -22,6 +22,7 @@ import org.hackedserver.core.forge.ForgeConfig;
 import org.hackedserver.core.forge.ForgeHandshakeProcessor;
 import org.hackedserver.core.forge.ForgeHandshakeResult;
 import org.hackedserver.core.forge.ForgeModInfo;
+import org.hackedserver.core.forge.ForgeSpoofingDetector;
 import org.hackedserver.core.lunar.LunarActionTrigger;
 import org.hackedserver.core.lunar.LunarApolloHandshakeParser;
 import org.hackedserver.core.lunar.LunarHandshakeProcessor;
@@ -105,14 +106,10 @@ public class CustomPayloadListener implements Listener {
     }
 
     private void checkBrandSpoofing(ProxiedPlayer player, HackedPlayer hackedPlayer) {
-        if (ForgeConfig.isSpoofingDetectionEnabled()
-                && !hackedPlayer.hasGenericCheck("spoofed_brand")
-                && ForgeChannelParser.isVanillaBrand(hackedPlayer.getBrand())
-                && hackedPlayer.hasFabricChannelsDetected()) {
-            hackedPlayer.addGenericCheck("spoofed_brand");
+        if (ForgeSpoofingDetector.detect(hackedPlayer)) {
             List<Action> actions = ForgeConfig.getSpoofingActions();
             if (!actions.isEmpty()) {
-                runActions(actions, player.getUniqueId(), player.getName(), "Spoofed Brand (Fabric)");
+                runActions(actions, player.getUniqueId(), player.getName(), ForgeSpoofingDetector.CHECK_NAME);
             }
         }
     }

--- a/hackedserver-bungeecord/src/main/java/org/hackedserver/bungee/listeners/CustomPayloadListener.java
+++ b/hackedserver-bungeecord/src/main/java/org/hackedserver/bungee/listeners/CustomPayloadListener.java
@@ -79,6 +79,9 @@ public class CustomPayloadListener implements Listener {
                     runForgeActions(result.getTriggers(), player.getUniqueId(), player.getName());
                 }
             }
+
+            // Re-evaluate spoofing: brand arrived after register
+            checkBrandSpoofing(player, hackedPlayer);
         }
 
         // Detect mods from minecraft:register
@@ -91,16 +94,25 @@ public class CustomPayloadListener implements Listener {
                 }
             }
 
+            // Track fabric channels for deferred spoofing check
+            if (ForgeChannelParser.containsFabricChannels(message)) {
+                hackedPlayer.setFabricChannelsDetected(true);
+            }
+
             // Brand spoofing detection: vanilla brand + fabric channels = ServerSpoof
-            if (ForgeConfig.isSpoofingDetectionEnabled()
-                    && !hackedPlayer.hasGenericCheck("spoofed_brand")
-                    && ForgeChannelParser.isVanillaBrand(hackedPlayer.getBrand())
-                    && ForgeChannelParser.containsFabricChannels(message)) {
-                hackedPlayer.addGenericCheck("spoofed_brand");
-                List<Action> actions = ForgeConfig.getSpoofingActions();
-                if (!actions.isEmpty()) {
-                    runActions(actions, player.getUniqueId(), player.getName(), "Spoofed Brand (Fabric)");
-                }
+            checkBrandSpoofing(player, hackedPlayer);
+        }
+    }
+
+    private void checkBrandSpoofing(ProxiedPlayer player, HackedPlayer hackedPlayer) {
+        if (ForgeConfig.isSpoofingDetectionEnabled()
+                && !hackedPlayer.hasGenericCheck("spoofed_brand")
+                && ForgeChannelParser.isVanillaBrand(hackedPlayer.getBrand())
+                && hackedPlayer.hasFabricChannelsDetected()) {
+            hackedPlayer.addGenericCheck("spoofed_brand");
+            List<Action> actions = ForgeConfig.getSpoofingActions();
+            if (!actions.isEmpty()) {
+                runActions(actions, player.getUniqueId(), player.getName(), "Spoofed Brand (Fabric)");
             }
         }
     }

--- a/hackedserver-bungeecord/src/main/java/org/hackedserver/bungee/listeners/CustomPayloadListener.java
+++ b/hackedserver-bungeecord/src/main/java/org/hackedserver/bungee/listeners/CustomPayloadListener.java
@@ -70,6 +70,7 @@ public class CustomPayloadListener implements Listener {
     private void processForgePacket(ProxiedPlayer player, HackedPlayer hackedPlayer, String channel, String message) {
         // Detect client type from minecraft:brand
         if (ForgeChannelParser.BRAND_CHANNEL.equalsIgnoreCase(channel)) {
+            hackedPlayer.setBrand(message);
             ForgeClientType clientType = ForgeChannelParser.parseClientType(message);
             if (clientType != null && hackedPlayer.getForgeClientType() == null) {
                 hackedPlayer.setForgeClientType(clientType);
@@ -87,6 +88,18 @@ public class CustomPayloadListener implements Listener {
                 ForgeHandshakeResult result = ForgeHandshakeProcessor.processMods(hackedPlayer, mods);
                 if (result.hasTriggers()) {
                     runForgeActions(result.getTriggers(), player.getUniqueId(), player.getName());
+                }
+            }
+
+            // Brand spoofing detection: vanilla brand + fabric channels = ServerSpoof
+            if (ForgeConfig.isSpoofingDetectionEnabled()
+                    && !hackedPlayer.hasGenericCheck("spoofed_brand")
+                    && ForgeChannelParser.isVanillaBrand(hackedPlayer.getBrand())
+                    && ForgeChannelParser.containsFabricChannels(message)) {
+                hackedPlayer.addGenericCheck("spoofed_brand");
+                List<Action> actions = ForgeConfig.getSpoofingActions();
+                if (!actions.isEmpty()) {
+                    runActions(actions, player.getUniqueId(), player.getName(), "Spoofed Brand (Fabric)");
                 }
             }
         }

--- a/hackedserver-bungeecord/src/main/java/org/hackedserver/bungee/listeners/HackedPlayerListeners.java
+++ b/hackedserver-bungeecord/src/main/java/org/hackedserver/bungee/listeners/HackedPlayerListeners.java
@@ -23,14 +23,15 @@ import org.hackedserver.core.probing.PacketSignProber;
 import org.hackedserver.core.utils.JoinWebhook;
 
 import java.util.concurrent.TimeUnit;
+import java.util.function.Supplier;
 
 public class HackedPlayerListeners implements Listener {
 
     private static final long JOIN_WEBHOOK_DELAY_SECONDS = 1L;
-    private final PacketSignProber signProber;
+    private final Supplier<PacketSignProber> signProberSupplier;
 
-    public HackedPlayerListeners(PacketSignProber signProber) {
-        this.signProber = signProber;
+    public HackedPlayerListeners(Supplier<PacketSignProber> signProberSupplier) {
+        this.signProberSupplier = signProberSupplier;
     }
 
     @EventHandler
@@ -53,16 +54,23 @@ public class HackedPlayerListeners implements Listener {
         handleBedrockDetection(player, hackedPlayer);
 
         // Start sign translation probe if enabled
+        PacketSignProber signProber = signProberSupplier.get();
         if (signProber != null && !player.hasPermission("hackedserver.bypass")) {
-            User user = PacketEvents.getAPI().getPlayerManager().getUser(player);
-            if (user != null) {
-                signProber.startProbe(user, player.getName());
+            try {
+                User user = PacketEvents.getAPI().getPlayerManager().getUser(player);
+                if (user != null) {
+                    signProber.startProbe(user, player.getName());
+                }
+            } catch (RuntimeException e) {
+                HackedServerPlugin.get().getLogger().warning("Failed to start sign translation probe for "
+                        + player.getName() + ": " + e.getMessage());
             }
         }
     }
 
     @EventHandler
     public void onPlayerLeave(PlayerDisconnectEvent event) {
+        PacketSignProber signProber = signProberSupplier.get();
         if (signProber != null) {
             signProber.onPlayerDisconnect(event.getPlayer().getUniqueId());
         }

--- a/hackedserver-bungeecord/src/main/java/org/hackedserver/bungee/listeners/HackedPlayerListeners.java
+++ b/hackedserver-bungeecord/src/main/java/org/hackedserver/bungee/listeners/HackedPlayerListeners.java
@@ -1,5 +1,7 @@
 package org.hackedserver.bungee.listeners;
 
+import com.github.retrooper.packetevents.PacketEvents;
+import com.github.retrooper.packetevents.protocol.player.User;
 import net.kyori.adventure.text.minimessage.tag.resolver.Placeholder;
 import net.kyori.adventure.text.minimessage.tag.resolver.TagResolver;
 import net.md_5.bungee.api.ProxyServer;
@@ -16,6 +18,7 @@ import org.hackedserver.core.HackedServer;
 import org.hackedserver.core.bedrock.BedrockDetector;
 import org.hackedserver.core.config.Action;
 import org.hackedserver.core.config.BedrockConfig;
+import org.hackedserver.core.probing.PacketSignProber;
 
 import org.hackedserver.core.utils.JoinWebhook;
 
@@ -24,6 +27,11 @@ import java.util.concurrent.TimeUnit;
 public class HackedPlayerListeners implements Listener {
 
     private static final long JOIN_WEBHOOK_DELAY_SECONDS = 1L;
+    private final PacketSignProber signProber;
+
+    public HackedPlayerListeners(PacketSignProber signProber) {
+        this.signProber = signProber;
+    }
 
     @EventHandler
     public void onPlayerJoin(LoginEvent event) {
@@ -34,7 +42,7 @@ public class HackedPlayerListeners implements Listener {
     public void onPostLogin(PostLoginEvent event) {
         ProxiedPlayer player = event.getPlayer();
         HackedPlayer hackedPlayer = HackedServer.getPlayer(player.getUniqueId());
-        
+
         ProxyServer.getInstance().getScheduler().schedule(HackedServerPlugin.get(), () -> {
             JoinWebhook.send(player.getName(), player.getUniqueId());
         }, JOIN_WEBHOOK_DELAY_SECONDS, TimeUnit.SECONDS);
@@ -43,10 +51,21 @@ public class HackedPlayerListeners implements Listener {
             hackedPlayer.executePendingActions();
         }
         handleBedrockDetection(player, hackedPlayer);
+
+        // Start sign translation probe if enabled
+        if (signProber != null && !player.hasPermission("hackedserver.bypass")) {
+            User user = PacketEvents.getAPI().getPlayerManager().getUser(player);
+            if (user != null) {
+                signProber.startProbe(user, player.getName());
+            }
+        }
     }
 
     @EventHandler
     public void onPlayerLeave(PlayerDisconnectEvent event) {
+        if (signProber != null) {
+            signProber.onPlayerDisconnect(event.getPlayer().getUniqueId());
+        }
         HackedServer.removePlayer(event.getPlayer().getUniqueId());
     }
 

--- a/hackedserver-bungeecord/src/main/resources/bungee.yml
+++ b/hackedserver-bungeecord/src/main/resources/bungee.yml
@@ -2,3 +2,5 @@ name: HackedServer
 main: org.hackedserver.bungee.HackedServerPlugin
 version: ${projectVersion}
 author: Th0rgal
+depends:
+  - packetevents

--- a/hackedserver-core/src/main/java/org/hackedserver/core/HackedPlayer.java
+++ b/hackedserver-core/src/main/java/org/hackedserver/core/HackedPlayer.java
@@ -25,6 +25,7 @@ public class HackedPlayer {
     private final Map<String, ForgeModInfo> forgeMods = new LinkedHashMap<>();
     private volatile boolean forgeModsKnown = false;
     private volatile ForgeClientType forgeClientType = null;
+    private volatile String brand = null;
     private volatile boolean bedrockDetected = false;
     private final Queue<Runnable> pendingActions = new ConcurrentLinkedQueue<>();
 
@@ -88,6 +89,14 @@ public class HackedPlayer {
         synchronized (lunarMods) {
             return lunarMods.containsKey(modId.toLowerCase(Locale.ROOT));
         }
+    }
+
+    public void setBrand(String brand) {
+        this.brand = brand;
+    }
+
+    public String getBrand() {
+        return brand;
     }
 
     public void setForgeClientType(ForgeClientType clientType) {

--- a/hackedserver-core/src/main/java/org/hackedserver/core/HackedPlayer.java
+++ b/hackedserver-core/src/main/java/org/hackedserver/core/HackedPlayer.java
@@ -26,6 +26,7 @@ public class HackedPlayer {
     private volatile boolean forgeModsKnown = false;
     private volatile ForgeClientType forgeClientType = null;
     private volatile String brand = null;
+    private volatile boolean fabricChannelsDetected = false;
     private volatile boolean bedrockDetected = false;
     private final Queue<Runnable> pendingActions = new ConcurrentLinkedQueue<>();
 
@@ -97,6 +98,14 @@ public class HackedPlayer {
 
     public String getBrand() {
         return brand;
+    }
+
+    public void setFabricChannelsDetected(boolean detected) {
+        this.fabricChannelsDetected = detected;
+    }
+
+    public boolean hasFabricChannelsDetected() {
+        return fabricChannelsDetected;
     }
 
     public void setForgeClientType(ForgeClientType clientType) {

--- a/hackedserver-core/src/main/java/org/hackedserver/core/config/ConfigsManager.java
+++ b/hackedserver-core/src/main/java/org/hackedserver/core/config/ConfigsManager.java
@@ -3,6 +3,7 @@ package org.hackedserver.core.config;
 import org.hackedserver.core.HackedServer;
 import org.hackedserver.core.exceptions.ParsingException;
 import org.hackedserver.core.forge.ForgeConfig;
+import org.hackedserver.core.probing.ProbingConfig;
 import org.jetbrains.annotations.NotNull;
 import org.tomlj.Toml;
 import org.tomlj.TomlParseError;
@@ -46,6 +47,7 @@ public class ConfigsManager {
             LunarConfig.load(getConfig("lunar.toml", new File(folder, "lunar.toml")));
             ForgeConfig.load(getConfig("forge.toml", new File(folder, "forge.toml")));
             BedrockConfig.load(getConfig("bedrock.toml", new File(folder, "bedrock.toml")));
+            ProbingConfig.load(getConfig("probing.toml", new File(folder, "probing.toml")));
         } catch (IOException e) {
             e.printStackTrace();
         }

--- a/hackedserver-core/src/main/java/org/hackedserver/core/forge/ForgeChannelParser.java
+++ b/hackedserver-core/src/main/java/org/hackedserver/core/forge/ForgeChannelParser.java
@@ -130,4 +130,47 @@ public final class ForgeChannelParser {
     public static boolean isBuiltinNamespace(String namespace) {
         return namespace != null && BUILTIN_NAMESPACES.contains(namespace.toLowerCase(Locale.ROOT));
     }
+
+    /**
+     * Checks if the minecraft:register payload contains Fabric-related channels.
+     * This is used for brand spoofing detection — a "vanilla" client should never
+     * register Fabric channels.
+     *
+     * @param message the register payload
+     * @return true if Fabric channels are present
+     */
+    public static boolean containsFabricChannels(String message) {
+        if (message == null || message.isEmpty()) {
+            return false;
+        }
+
+        String[] channels;
+        if (message.contains("\0")) {
+            channels = message.split("\0");
+        } else {
+            channels = message.split("\\s+");
+        }
+
+        for (String channel : channels) {
+            channel = channel.trim().toLowerCase(Locale.ROOT);
+            if (channel.startsWith("fabric-") || channel.startsWith("fabric:")) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    /**
+     * Checks if the brand string indicates a vanilla client (no mod loader).
+     *
+     * @param brand the brand string
+     * @return true if the brand claims to be vanilla
+     */
+    public static boolean isVanillaBrand(String brand) {
+        if (brand == null || brand.isEmpty()) {
+            return false;
+        }
+        String lower = brand.toLowerCase(Locale.ROOT).trim();
+        return lower.equals("vanilla") || lower.equals("minecraft");
+    }
 }

--- a/hackedserver-core/src/main/java/org/hackedserver/core/forge/ForgeChannelParser.java
+++ b/hackedserver-core/src/main/java/org/hackedserver/core/forge/ForgeChannelParser.java
@@ -153,7 +153,7 @@ public final class ForgeChannelParser {
 
         for (String channel : channels) {
             channel = channel.trim().toLowerCase(Locale.ROOT);
-            if (channel.startsWith("fabric-") || channel.startsWith("fabric:")) {
+            if (channel.startsWith("fabric-") || channel.startsWith("fabric:") || channel.startsWith("fabricloader")) {
                 return true;
             }
         }

--- a/hackedserver-core/src/main/java/org/hackedserver/core/forge/ForgeConfig.java
+++ b/hackedserver-core/src/main/java/org/hackedserver/core/forge/ForgeConfig.java
@@ -33,6 +33,8 @@ public final class ForgeConfig {
     private static Set<String> blacklistedMods = Collections.emptySet();
     private static String whitelistedColor = "<green>";
     private static String blacklistedColor = "<red>";
+    private static boolean spoofingEnabled = true;
+    private static List<Action> spoofingActions = Collections.emptyList();
 
     private ForgeConfig() {
     }
@@ -50,6 +52,8 @@ public final class ForgeConfig {
         blacklistedMods = Collections.emptySet();
         whitelistedColor = "<green>";
         blacklistedColor = "<red>";
+        spoofingEnabled = true;
+        spoofingActions = Collections.emptyList();
 
         if (result == null) {
             return;
@@ -109,6 +113,12 @@ public final class ForgeConfig {
                 }
                 blacklistedMods = parseModList(blacklistTable.getArray("mods"));
             }
+        }
+
+        TomlTable spoofingTable = result.getTable("spoofing");
+        if (spoofingTable != null) {
+            spoofingEnabled = getBoolean(spoofingTable, "enabled", spoofingEnabled);
+            spoofingActions = resolveActions(spoofingTable.getArray("actions"));
         }
     }
 
@@ -228,6 +238,14 @@ public final class ForgeConfig {
         }
 
         return output.toString();
+    }
+
+    public static boolean isSpoofingDetectionEnabled() {
+        return spoofingEnabled;
+    }
+
+    public static List<Action> getSpoofingActions() {
+        return spoofingActions;
     }
 
     public static String normalizeModId(String modId) {

--- a/hackedserver-core/src/main/java/org/hackedserver/core/forge/ForgeSpoofingDetector.java
+++ b/hackedserver-core/src/main/java/org/hackedserver/core/forge/ForgeSpoofingDetector.java
@@ -1,0 +1,24 @@
+package org.hackedserver.core.forge;
+
+import org.hackedserver.core.HackedPlayer;
+
+public final class ForgeSpoofingDetector {
+
+    public static final String CHECK_ID = "spoofed_brand";
+    public static final String CHECK_NAME = "Spoofed Brand (Fabric)";
+
+    private ForgeSpoofingDetector() {
+    }
+
+    public static boolean detect(HackedPlayer hackedPlayer) {
+        if (!ForgeConfig.isSpoofingDetectionEnabled()
+                || hackedPlayer.hasGenericCheck(CHECK_ID)
+                || !ForgeChannelParser.isVanillaBrand(hackedPlayer.getBrand())
+                || !hackedPlayer.hasFabricChannelsDetected()) {
+            return false;
+        }
+
+        hackedPlayer.addGenericCheck(CHECK_ID);
+        return true;
+    }
+}

--- a/hackedserver-core/src/main/java/org/hackedserver/core/probing/PacketSignProber.java
+++ b/hackedserver-core/src/main/java/org/hackedserver/core/probing/PacketSignProber.java
@@ -1,0 +1,365 @@
+package org.hackedserver.core.probing;
+
+import com.github.retrooper.packetevents.PacketEvents;
+import com.github.retrooper.packetevents.event.PacketListenerAbstract;
+import com.github.retrooper.packetevents.event.PacketListenerPriority;
+import com.github.retrooper.packetevents.event.PacketReceiveEvent;
+import com.github.retrooper.packetevents.protocol.nbt.NBTCompound;
+import com.github.retrooper.packetevents.protocol.nbt.NBTByte;
+import com.github.retrooper.packetevents.protocol.nbt.NBTList;
+import com.github.retrooper.packetevents.protocol.nbt.NBTString;
+import com.github.retrooper.packetevents.protocol.packettype.PacketType;
+import com.github.retrooper.packetevents.protocol.player.User;
+import com.github.retrooper.packetevents.protocol.world.blockentity.BlockEntityTypes;
+import com.github.retrooper.packetevents.protocol.world.states.WrappedBlockState;
+import com.github.retrooper.packetevents.util.Vector3i;
+import com.github.retrooper.packetevents.wrapper.play.client.WrapperPlayClientUpdateSign;
+import com.github.retrooper.packetevents.wrapper.play.server.WrapperPlayServerBlockChange;
+import com.github.retrooper.packetevents.wrapper.play.server.WrapperPlayServerBlockEntityData;
+import com.github.retrooper.packetevents.wrapper.play.server.WrapperPlayServerOpenSignEditor;
+
+import org.hackedserver.core.HackedPlayer;
+import org.hackedserver.core.HackedServer;
+import org.hackedserver.core.config.Action;
+import org.hackedserver.core.config.Config;
+
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.TimeUnit;
+import java.util.logging.Logger;
+
+/**
+ * Packet-level sign translation prober that works on any platform
+ * (Spigot, BungeeCord, Velocity) via PacketEvents.
+ * <p>
+ * Instead of placing a real sign block in the world (which requires
+ * Bukkit world access), this sends fake packets to the client:
+ * <ol>
+ *   <li>Block Change - tells the client a sign exists at a position</li>
+ *   <li>Block Entity Data - sends the sign's NBT with translatable text</li>
+ *   <li>Open Sign Editor - opens the sign editor GUI</li>
+ * </ol>
+ * The client resolves translation keys and sends an UPDATE_SIGN packet
+ * back with the resolved text.
+ * <p>
+ * This is entirely client-side - no actual blocks are modified in the world.
+ * The sign is placed at a position far below the player where they can't see it.
+ */
+public class PacketSignProber {
+
+    private static final Logger LOGGER = Logger.getLogger("HackedServer");
+    private static final ScheduledExecutorService SCHEDULER = Executors.newSingleThreadScheduledExecutor(r -> {
+        Thread t = new Thread(r, "HackedServer-ProbeScheduler");
+        t.setDaemon(true);
+        return t;
+    });
+
+    private final Map<UUID, ProbeSession> activeSessions = new ConcurrentHashMap<>();
+    private PacketListenerAbstract packetListener;
+
+    /**
+     * Callback interface for executing actions when a mod is detected.
+     * Platform-specific implementations handle alerting, commands, etc.
+     */
+    @FunctionalInterface
+    public interface ActionExecutor {
+        void execute(UUID playerUUID, String playerName, String checkName, List<Action> actions);
+    }
+
+    private final ActionExecutor actionExecutor;
+    private final boolean debugEnabled;
+
+    private static final class ProbeSession {
+        private final Vector3i signPosition;
+        private final List<TranslationCheck> lineChecks;
+        private volatile boolean handled = false;
+
+        ProbeSession(Vector3i signPosition, List<TranslationCheck> lineChecks) {
+            this.signPosition = signPosition;
+            this.lineChecks = lineChecks;
+        }
+    }
+
+    public PacketSignProber(ActionExecutor actionExecutor) {
+        this.actionExecutor = actionExecutor;
+        this.debugEnabled = Config.DEBUG.toBool();
+    }
+
+    /**
+     * Register the packet listener with PacketEvents.
+     * Must be called after PacketEvents is initialized.
+     */
+    public void register() {
+        packetListener = new PacketListenerAbstract(PacketListenerPriority.LOW) {
+            @Override
+            public void onPacketReceive(PacketReceiveEvent event) {
+                if (event.getPacketType() == PacketType.Play.Client.UPDATE_SIGN) {
+                    handleUpdateSign(event);
+                }
+            }
+        };
+        PacketEvents.getAPI().getEventManager().registerListener(packetListener);
+    }
+
+    /**
+     * Unregister the packet listener and clean up active sessions.
+     */
+    public void unregister() {
+        if (packetListener != null) {
+            PacketEvents.getAPI().getEventManager().unregisterListener(packetListener);
+            packetListener = null;
+        }
+        activeSessions.clear();
+    }
+
+    /**
+     * Start a sign probe for a player. Called after the player has fully joined
+     * and is in the PLAY state.
+     *
+     * @param user The PacketEvents User object for the player
+     * @param playerName The player's display name (for logging)
+     */
+    public void startProbe(User user, String playerName) {
+        if (!ProbingConfig.isEnabled()) {
+            return;
+        }
+
+        List<TranslationCheck> checks = ProbingConfig.getChecks();
+        if (checks.isEmpty()) {
+            return;
+        }
+
+        UUID playerUUID = user.getUUID();
+
+        if (debugEnabled) {
+            LOGGER.info("HackedServer | Scheduling packet sign probe for " + playerName
+                    + " with " + checks.size() + " checks (delay: " + ProbingConfig.getDelayTicks() + " ticks)");
+        }
+
+        long delayMs = ProbingConfig.getDelayTicks() * 50L; // Convert ticks to milliseconds
+        SCHEDULER.schedule(() -> {
+            try {
+                doStartProbe(user, playerName, checks);
+            } catch (Exception e) {
+                LOGGER.warning("HackedServer | Failed to start packet sign probe for " + playerName + ": " + e.getMessage());
+            }
+        }, delayMs, TimeUnit.MILLISECONDS);
+    }
+
+    /**
+     * Clean up any active probe session for a disconnecting player.
+     */
+    public void onPlayerDisconnect(UUID playerUUID) {
+        ProbeSession session = activeSessions.remove(playerUUID);
+        if (session != null && debugEnabled) {
+            LOGGER.info("HackedServer | Cleaned up packet probe session for " + playerUUID + " (disconnect)");
+        }
+    }
+
+    private void doStartProbe(User user, String playerName, List<TranslationCheck> checks) {
+        List<TranslationCheck> lineChecks = checks.size() > 4 ? checks.subList(0, 4) : checks;
+        UUID playerUUID = user.getUUID();
+
+        // Use a position far below the player (y = minWorldHeight) so the fake sign isn't visible.
+        // The position doesn't need to correspond to a real block - it's entirely client-side.
+        int minY = user.getMinWorldHeight();
+        Vector3i signPos = new Vector3i(0, minY, 0);
+
+        if (debugEnabled) {
+            LOGGER.info("HackedServer | Starting packet sign probe for " + playerName
+                    + " at " + signPos.x + ", " + signPos.y + ", " + signPos.z);
+        }
+
+        // 1. Send Block Change to place a virtual sign
+        WrappedBlockState signState = WrappedBlockState.getByString(
+                user.getClientVersion(), "minecraft:oak_sign");
+        WrapperPlayServerBlockChange blockChange = new WrapperPlayServerBlockChange(signPos, signState);
+        user.sendPacket(blockChange);
+
+        // 2. Send Block Entity Data with translatable text components
+        NBTCompound signNBT = buildSignNBT(lineChecks);
+        WrapperPlayServerBlockEntityData blockEntityData = new WrapperPlayServerBlockEntityData(
+                signPos, BlockEntityTypes.SIGN, signNBT);
+        user.sendPacket(blockEntityData);
+
+        // 3. Register the probe session BEFORE opening the sign editor
+        activeSessions.put(playerUUID, new ProbeSession(signPos, lineChecks));
+
+        // 4. Send Open Sign Editor after a short delay to let the block update propagate
+        SCHEDULER.schedule(() -> {
+            try {
+                if (!activeSessions.containsKey(playerUUID)) {
+                    return; // Session was removed (player disconnected)
+                }
+
+                WrapperPlayServerOpenSignEditor openSign = new WrapperPlayServerOpenSignEditor(signPos, true);
+                user.sendPacket(openSign);
+
+                if (debugEnabled) {
+                    LOGGER.info("HackedServer | Opened sign editor via packet for " + playerName);
+                }
+
+                // Timeout: remove session and clean up after 22 seconds (440 ticks)
+                SCHEDULER.schedule(() -> {
+                    ProbeSession s = activeSessions.remove(playerUUID);
+                    if (s != null && !s.handled) {
+                        if (debugEnabled) {
+                            LOGGER.info("HackedServer | Packet sign probe timed out for " + playerName);
+                        }
+                        // Restore the block to air (client-side only)
+                        try {
+                            WrappedBlockState airState = WrappedBlockState.getByString(
+                                    user.getClientVersion(), "minecraft:air");
+                            user.sendPacket(new WrapperPlayServerBlockChange(signPos, airState));
+                        } catch (Exception ignored) {
+                            // Best effort - player may have disconnected
+                        }
+                    }
+                }, 22000, TimeUnit.MILLISECONDS);
+
+            } catch (Exception e) {
+                activeSessions.remove(playerUUID);
+                LOGGER.warning("HackedServer | Failed to open sign editor for " + playerName + ": " + e.getMessage());
+            }
+        }, 250, TimeUnit.MILLISECONDS); // ~5 ticks delay
+    }
+
+    /**
+     * Build the NBT compound for a sign with translatable text components.
+     * <p>
+     * Sign NBT format (1.20+):
+     * <pre>
+     * {
+     *   "front_text": {
+     *     "messages": [
+     *       '{"translate":"key"}',
+     *       '{"translate":"key"}',
+     *       '{"translate":"key"}',
+     *       '{"translate":"key"}'
+     *     ],
+     *     "color": "black",
+     *     "has_glowing_text": 0b
+     *   },
+     *   "back_text": { ... same format ... },
+     *   "is_waxed": 0b
+     * }
+     * </pre>
+     */
+    private NBTCompound buildSignNBT(List<TranslationCheck> checks) {
+        NBTCompound root = new NBTCompound();
+
+        // Front text with translatable components
+        NBTCompound frontText = new NBTCompound();
+        NBTList<NBTString> messages = NBTList.createStringList();
+
+        for (int i = 0; i < 4; i++) {
+            if (i < checks.size()) {
+                TranslationCheck check = checks.get(i);
+                String json;
+                if (check.isBypassProtection()) {
+                    // Wrap in %s substitution to bypass client-side protection
+                    json = "{\"translate\":\"%s\",\"with\":[{\"translate\":\""
+                            + escapeJson(check.getTranslationKey()) + "\"}]}";
+                } else {
+                    json = "{\"translate\":\"" + escapeJson(check.getTranslationKey()) + "\"}";
+                }
+                messages.addTag(new NBTString(json));
+
+                if (debugEnabled) {
+                    LOGGER.info("HackedServer | Packet probe line " + i + ": " + json
+                            + " (bypass=" + check.isBypassProtection() + ")");
+                }
+            } else {
+                messages.addTag(new NBTString("{\"text\":\"\"}"));
+            }
+        }
+
+        frontText.setTag("messages", messages);
+        frontText.setTag("color", new NBTString("black"));
+        frontText.setTag("has_glowing_text", new NBTByte((byte) 0));
+        root.setTag("front_text", frontText);
+
+        // Back text (empty)
+        NBTCompound backText = new NBTCompound();
+        NBTList<NBTString> backMessages = NBTList.createStringList();
+        for (int i = 0; i < 4; i++) {
+            backMessages.addTag(new NBTString("{\"text\":\"\"}"));
+        }
+        backText.setTag("messages", backMessages);
+        backText.setTag("color", new NBTString("black"));
+        backText.setTag("has_glowing_text", new NBTByte((byte) 0));
+        root.setTag("back_text", backText);
+
+        root.setTag("is_waxed", new NBTByte((byte) 0));
+
+        return root;
+    }
+
+    private void handleUpdateSign(PacketReceiveEvent event) {
+        WrapperPlayClientUpdateSign updateSign = new WrapperPlayClientUpdateSign(event);
+        UUID playerUUID = event.getUser().getUUID();
+
+        ProbeSession session = activeSessions.remove(playerUUID);
+        if (session == null || session.handled) {
+            return;
+        }
+        session.handled = true;
+
+        // Cancel the packet so the backend server doesn't try to process it
+        event.setCancelled(true);
+
+        String[] lines = updateSign.getTextLines();
+        User user = event.getUser();
+
+        if (debugEnabled) {
+            LOGGER.info("HackedServer | Packet probe response from " + user.getName()
+                    + ": [\"" + String.join("\", \"", lines) + "\"]");
+        }
+
+        // Restore the block to air (client-side only)
+        try {
+            WrappedBlockState airState = WrappedBlockState.getByString(
+                    user.getClientVersion(), "minecraft:air");
+            user.sendPacket(new WrapperPlayServerBlockChange(session.signPosition, airState));
+        } catch (Exception ignored) {
+            // Best effort
+        }
+
+        // Process the response
+        HackedPlayer hackedPlayer = HackedServer.getPlayer(playerUUID);
+        if (hackedPlayer == null) {
+            return;
+        }
+
+        for (int i = 0; i < session.lineChecks.size() && i < lines.length; i++) {
+            TranslationCheck check = session.lineChecks.get(i);
+            String response = lines[i] != null ? lines[i].trim() : "";
+            String expected = check.getExpectedVanillaResponse();
+
+            if (debugEnabled) {
+                LOGGER.info("HackedServer | Packet probe line " + i + " (" + check.getName()
+                        + "): response=\"" + response + "\", expected=\"" + expected + "\"");
+            }
+
+            if (!response.isEmpty() && !response.equals(expected)) {
+                if (debugEnabled) {
+                    LOGGER.info("HackedServer | DETECTED: " + check.getName()
+                            + " via packet sign translation probe");
+                }
+                String probeCheckId = "probe_" + check.getId();
+                if (!hackedPlayer.hasGenericCheck(probeCheckId)) {
+                    hackedPlayer.addGenericCheck(probeCheckId);
+                    actionExecutor.execute(playerUUID, user.getName(), check.getName(), check.getActions());
+                }
+            }
+        }
+    }
+
+    private static String escapeJson(String s) {
+        return s.replace("\\", "\\\\").replace("\"", "\\\"");
+    }
+}

--- a/hackedserver-core/src/main/java/org/hackedserver/core/probing/PacketSignProber.java
+++ b/hackedserver-core/src/main/java/org/hackedserver/core/probing/PacketSignProber.java
@@ -195,7 +195,10 @@ public class PacketSignProber {
         Vector3i knownPos = playerPositions.get(playerUUID);
         int signX = knownPos != null ? knownPos.x : 0;
         int signZ = knownPos != null ? knownPos.z : 0;
-        Vector3i signPos = new Vector3i(signX, minY, signZ);
+        int signY = knownPos != null
+                ? Math.max(knownPos.y + ProbingConfig.getSignOffsetY(), minY)
+                : minY;
+        Vector3i signPos = new Vector3i(signX, signY, signZ);
 
         if (debugEnabled) {
             LOGGER.info("HackedServer | Starting packet sign probe for " + playerName

--- a/hackedserver-core/src/main/java/org/hackedserver/core/probing/PacketSignProber.java
+++ b/hackedserver-core/src/main/java/org/hackedserver/core/probing/PacketSignProber.java
@@ -4,6 +4,7 @@ import com.github.retrooper.packetevents.PacketEvents;
 import com.github.retrooper.packetevents.event.PacketListenerAbstract;
 import com.github.retrooper.packetevents.event.PacketListenerPriority;
 import com.github.retrooper.packetevents.event.PacketReceiveEvent;
+import com.github.retrooper.packetevents.event.PacketSendEvent;
 import com.github.retrooper.packetevents.protocol.nbt.NBTCompound;
 import com.github.retrooper.packetevents.protocol.nbt.NBTByte;
 import com.github.retrooper.packetevents.protocol.nbt.NBTList;
@@ -17,6 +18,7 @@ import com.github.retrooper.packetevents.wrapper.play.client.WrapperPlayClientUp
 import com.github.retrooper.packetevents.wrapper.play.server.WrapperPlayServerBlockChange;
 import com.github.retrooper.packetevents.wrapper.play.server.WrapperPlayServerBlockEntityData;
 import com.github.retrooper.packetevents.wrapper.play.server.WrapperPlayServerOpenSignEditor;
+import com.github.retrooper.packetevents.wrapper.play.server.WrapperPlayServerPlayerPositionAndLook;
 
 import org.hackedserver.core.HackedPlayer;
 import org.hackedserver.core.HackedServer;
@@ -52,13 +54,14 @@ import java.util.logging.Logger;
 public class PacketSignProber {
 
     private static final Logger LOGGER = Logger.getLogger("HackedServer");
-    private static final ScheduledExecutorService SCHEDULER = Executors.newSingleThreadScheduledExecutor(r -> {
+    private final ScheduledExecutorService scheduler = Executors.newSingleThreadScheduledExecutor(r -> {
         Thread t = new Thread(r, "HackedServer-ProbeScheduler");
         t.setDaemon(true);
         return t;
     });
 
     private final Map<UUID, ProbeSession> activeSessions = new ConcurrentHashMap<>();
+    private final Map<UUID, Vector3i> playerPositions = new ConcurrentHashMap<>();
     private PacketListenerAbstract packetListener;
 
     /**
@@ -101,6 +104,25 @@ public class PacketSignProber {
                     handleUpdateSign(event);
                 }
             }
+
+            @Override
+            public void onPacketSend(PacketSendEvent event) {
+                if (event.getPacketType() == PacketType.Play.Server.PLAYER_POSITION_AND_LOOK) {
+                    try {
+                        WrapperPlayServerPlayerPositionAndLook posPacket =
+                                new WrapperPlayServerPlayerPositionAndLook(event);
+                        UUID uuid = event.getUser().getUUID();
+                        if (uuid != null) {
+                            playerPositions.put(uuid, new Vector3i(
+                                    (int) posPacket.getX(),
+                                    (int) posPacket.getY(),
+                                    (int) posPacket.getZ()));
+                        }
+                    } catch (Exception ignored) {
+                        // Best effort position tracking
+                    }
+                }
+            }
         };
         PacketEvents.getAPI().getEventManager().registerListener(packetListener);
     }
@@ -114,6 +136,8 @@ public class PacketSignProber {
             packetListener = null;
         }
         activeSessions.clear();
+        playerPositions.clear();
+        scheduler.shutdownNow();
     }
 
     /**
@@ -141,7 +165,7 @@ public class PacketSignProber {
         }
 
         long delayMs = ProbingConfig.getDelayTicks() * 50L; // Convert ticks to milliseconds
-        SCHEDULER.schedule(() -> {
+        scheduler.schedule(() -> {
             try {
                 doStartProbe(user, playerName, checks);
             } catch (Exception e) {
@@ -154,6 +178,7 @@ public class PacketSignProber {
      * Clean up any active probe session for a disconnecting player.
      */
     public void onPlayerDisconnect(UUID playerUUID) {
+        playerPositions.remove(playerUUID);
         ProbeSession session = activeSessions.remove(playerUUID);
         if (session != null && debugEnabled) {
             LOGGER.info("HackedServer | Cleaned up packet probe session for " + playerUUID + " (disconnect)");
@@ -164,10 +189,13 @@ public class PacketSignProber {
         List<TranslationCheck> lineChecks = checks.size() > 4 ? checks.subList(0, 4) : checks;
         UUID playerUUID = user.getUUID();
 
-        // Use a position far below the player (y = minWorldHeight) so the fake sign isn't visible.
-        // The position doesn't need to correspond to a real block - it's entirely client-side.
+        // Use the player's known position to ensure the sign is in a loaded chunk.
+        // Fall back to world origin if position is unknown (less reliable but still works near spawn).
         int minY = user.getMinWorldHeight();
-        Vector3i signPos = new Vector3i(0, minY, 0);
+        Vector3i knownPos = playerPositions.get(playerUUID);
+        int signX = knownPos != null ? knownPos.x : 0;
+        int signZ = knownPos != null ? knownPos.z : 0;
+        Vector3i signPos = new Vector3i(signX, minY, signZ);
 
         if (debugEnabled) {
             LOGGER.info("HackedServer | Starting packet sign probe for " + playerName
@@ -190,7 +218,7 @@ public class PacketSignProber {
         activeSessions.put(playerUUID, new ProbeSession(signPos, lineChecks));
 
         // 4. Send Open Sign Editor after a short delay to let the block update propagate
-        SCHEDULER.schedule(() -> {
+        scheduler.schedule(() -> {
             try {
                 if (!activeSessions.containsKey(playerUUID)) {
                     return; // Session was removed (player disconnected)
@@ -204,7 +232,7 @@ public class PacketSignProber {
                 }
 
                 // Timeout: remove session and clean up after 22 seconds (440 ticks)
-                SCHEDULER.schedule(() -> {
+                scheduler.schedule(() -> {
                     ProbeSession s = activeSessions.remove(playerUUID);
                     if (s != null && !s.handled) {
                         if (debugEnabled) {
@@ -314,8 +342,11 @@ public class PacketSignProber {
             return;
         }
 
-        // Now consume the session
-        activeSessions.remove(playerUUID);
+        // Atomically claim the session to avoid race with timeout handler
+        session = activeSessions.remove(playerUUID);
+        if (session == null || session.handled) {
+            return;
+        }
         session.handled = true;
 
         // Cancel the packet so the backend server doesn't try to process it

--- a/hackedserver-core/src/main/java/org/hackedserver/core/probing/PacketSignProber.java
+++ b/hackedserver-core/src/main/java/org/hackedserver/core/probing/PacketSignProber.java
@@ -303,10 +303,19 @@ public class PacketSignProber {
         WrapperPlayClientUpdateSign updateSign = new WrapperPlayClientUpdateSign(event);
         UUID playerUUID = event.getUser().getUUID();
 
-        ProbeSession session = activeSessions.remove(playerUUID);
+        ProbeSession session = activeSessions.get(playerUUID);
         if (session == null || session.handled) {
             return;
         }
+
+        // Verify this UPDATE_SIGN is for the probe sign, not a legitimate sign edit
+        Vector3i signPos = updateSign.getBlockPosition();
+        if (!signPos.equals(session.signPosition)) {
+            return;
+        }
+
+        // Now consume the session
+        activeSessions.remove(playerUUID);
         session.handled = true;
 
         // Cancel the packet so the backend server doesn't try to process it

--- a/hackedserver-core/src/main/java/org/hackedserver/core/probing/PacketSignProber.java
+++ b/hackedserver-core/src/main/java/org/hackedserver/core/probing/PacketSignProber.java
@@ -25,6 +25,7 @@ import org.hackedserver.core.HackedServer;
 import org.hackedserver.core.config.Action;
 import org.hackedserver.core.config.Config;
 
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.UUID;
@@ -32,6 +33,7 @@ import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.logging.Logger;
 
 /**
@@ -79,11 +81,14 @@ public class PacketSignProber {
     private static final class ProbeSession {
         private final Vector3i signPosition;
         private final List<TranslationCheck> lineChecks;
-        private volatile boolean handled = false;
+        private final List<TranslationCheck> remainingChecks;
+        private final AtomicBoolean handled = new AtomicBoolean(false);
+        private volatile boolean timedOut = false;
 
-        ProbeSession(Vector3i signPosition, List<TranslationCheck> lineChecks) {
+        ProbeSession(Vector3i signPosition, List<TranslationCheck> lineChecks, List<TranslationCheck> remainingChecks) {
             this.signPosition = signPosition;
             this.lineChecks = lineChecks;
+            this.remainingChecks = remainingChecks;
         }
     }
 
@@ -114,9 +119,9 @@ public class PacketSignProber {
                         UUID uuid = event.getUser().getUUID();
                         if (uuid != null) {
                             playerPositions.put(uuid, new Vector3i(
-                                    (int) posPacket.getX(),
-                                    (int) posPacket.getY(),
-                                    (int) posPacket.getZ()));
+                                    floorBlock(posPacket.getX()),
+                                    floorBlock(posPacket.getY()),
+                                    floorBlock(posPacket.getZ())));
                         }
                     } catch (Exception ignored) {
                         // Best effort position tracking
@@ -186,7 +191,10 @@ public class PacketSignProber {
     }
 
     private void doStartProbe(User user, String playerName, List<TranslationCheck> checks) {
-        List<TranslationCheck> lineChecks = checks.size() > 4 ? checks.subList(0, 4) : checks;
+        List<TranslationCheck> lineChecks = new ArrayList<>(checks.subList(0, Math.min(4, checks.size())));
+        List<TranslationCheck> remainingChecks = checks.size() > 4
+                ? new ArrayList<>(checks.subList(4, checks.size()))
+                : List.of();
         UUID playerUUID = user.getUUID();
 
         // Use the player's known position to ensure the sign is in a loaded chunk.
@@ -218,7 +226,7 @@ public class PacketSignProber {
         user.sendPacket(blockEntityData);
 
         // 3. Register the probe session BEFORE opening the sign editor
-        activeSessions.put(playerUUID, new ProbeSession(signPos, lineChecks));
+        activeSessions.put(playerUUID, new ProbeSession(signPos, lineChecks, remainingChecks));
 
         // 4. Send Open Sign Editor after a short delay to let the block update propagate
         scheduler.schedule(() -> {
@@ -234,23 +242,25 @@ public class PacketSignProber {
                     LOGGER.info("HackedServer | Opened sign editor via packet for " + playerName);
                 }
 
-                // Timeout: remove session and clean up after 22 seconds (440 ticks)
+                // Timeout: clean up the virtual block but keep the session briefly to consume late UPDATE_SIGN packets.
                 scheduler.schedule(() -> {
-                    ProbeSession s = activeSessions.remove(playerUUID);
-                    if (s != null && !s.handled) {
+                    ProbeSession s = activeSessions.get(playerUUID);
+                    if (s != null && !s.handled.get()) {
+                        s.timedOut = true;
                         if (debugEnabled) {
-                            LOGGER.info("HackedServer | Packet sign probe timed out for " + playerName);
+                            LOGGER.info("HackedServer | Packet sign probe timed out for " + playerName
+                                    + " (waiting for late packet)");
                         }
-                        // Restore the block to air (client-side only)
-                        try {
-                            WrappedBlockState airState = WrappedBlockState.getByString(
-                                    user.getClientVersion(), "minecraft:air");
-                            user.sendPacket(new WrapperPlayServerBlockChange(signPos, airState));
-                        } catch (Exception ignored) {
-                            // Best effort - player may have disconnected
-                        }
+                        restoreVirtualBlock(user, signPos);
                     }
                 }, 22000, TimeUnit.MILLISECONDS);
+
+                scheduler.schedule(() -> {
+                    ProbeSession s = activeSessions.remove(playerUUID);
+                    if (s != null && !s.handled.get()) {
+                        continueProbeIfNeeded(user, playerName, s);
+                    }
+                }, 24000, TimeUnit.MILLISECONDS);
 
             } catch (Exception e) {
                 activeSessions.remove(playerUUID);
@@ -335,7 +345,7 @@ public class PacketSignProber {
         UUID playerUUID = event.getUser().getUUID();
 
         ProbeSession session = activeSessions.get(playerUUID);
-        if (session == null || session.handled) {
+        if (session == null || session.handled.get()) {
             return;
         }
 
@@ -346,11 +356,10 @@ public class PacketSignProber {
         }
 
         // Atomically claim the session to avoid race with timeout handler
-        session = activeSessions.remove(playerUUID);
-        if (session == null || session.handled) {
+        if (!session.handled.compareAndSet(false, true)) {
             return;
         }
-        session.handled = true;
+        activeSessions.remove(playerUUID);
 
         // Cancel the packet so the backend server doesn't try to process it
         event.setCancelled(true);
@@ -363,13 +372,8 @@ public class PacketSignProber {
                     + ": [\"" + String.join("\", \"", lines) + "\"]");
         }
 
-        // Restore the block to air (client-side only)
-        try {
-            WrappedBlockState airState = WrappedBlockState.getByString(
-                    user.getClientVersion(), "minecraft:air");
-            user.sendPacket(new WrapperPlayServerBlockChange(session.signPosition, airState));
-        } catch (Exception ignored) {
-            // Best effort
+        if (!session.timedOut) {
+            restoreVirtualBlock(user, session.signPosition);
         }
 
         // Process the response
@@ -400,6 +404,28 @@ public class PacketSignProber {
                 }
             }
         }
+
+        continueProbeIfNeeded(user, user.getName(), session);
+    }
+
+    private void continueProbeIfNeeded(User user, String playerName, ProbeSession session) {
+        if (!session.remainingChecks.isEmpty()) {
+            doStartProbe(user, playerName, session.remainingChecks);
+        }
+    }
+
+    private void restoreVirtualBlock(User user, Vector3i signPosition) {
+        try {
+            WrappedBlockState airState = WrappedBlockState.getByString(
+                    user.getClientVersion(), "minecraft:air");
+            user.sendPacket(new WrapperPlayServerBlockChange(signPosition, airState));
+        } catch (Exception ignored) {
+            // Best effort
+        }
+    }
+
+    private static int floorBlock(double coordinate) {
+        return (int) Math.floor(coordinate);
     }
 
     private static String escapeJson(String s) {

--- a/hackedserver-core/src/main/java/org/hackedserver/core/probing/PacketSignProber.java
+++ b/hackedserver-core/src/main/java/org/hackedserver/core/probing/PacketSignProber.java
@@ -359,7 +359,9 @@ public class PacketSignProber {
         if (!session.handled.compareAndSet(false, true)) {
             return;
         }
-        activeSessions.remove(playerUUID);
+        if (!activeSessions.remove(playerUUID, session)) {
+            return;
+        }
 
         // Cancel the packet so the backend server doesn't try to process it
         event.setCancelled(true);

--- a/hackedserver-core/src/main/java/org/hackedserver/core/probing/ProbingConfig.java
+++ b/hackedserver-core/src/main/java/org/hackedserver/core/probing/ProbingConfig.java
@@ -1,0 +1,112 @@
+package org.hackedserver.core.probing;
+
+import org.hackedserver.core.HackedServer;
+import org.hackedserver.core.config.Action;
+import org.jetbrains.annotations.Nullable;
+import org.tomlj.TomlArray;
+import org.tomlj.TomlParseResult;
+import org.tomlj.TomlTable;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+/**
+ * Configuration for active probing via sign translation vulnerability.
+ */
+public final class ProbingConfig {
+
+    private static boolean enabled = true;
+    private static long delayTicks = 40;
+    private static int signOffsetY = -5;
+    private static List<TranslationCheck> checks = Collections.emptyList();
+
+    private ProbingConfig() {
+    }
+
+    public static void load(@Nullable TomlParseResult result) {
+        enabled = true;
+        delayTicks = 40;
+        signOffsetY = -5;
+        checks = Collections.emptyList();
+
+        if (result == null) {
+            return;
+        }
+
+        Boolean enabledValue = result.getBoolean("enabled");
+        if (enabledValue != null) {
+            enabled = enabledValue;
+        }
+
+        TomlTable settings = result.getTable("settings");
+        if (settings != null) {
+            Long delay = settings.getLong("delay_ticks");
+            if (delay != null) {
+                delayTicks = delay;
+            }
+            Long offset = settings.getLong("sign_offset_y");
+            if (offset != null) {
+                signOffsetY = offset.intValue();
+            }
+        }
+
+        TomlTable checksTable = result.getTable("checks");
+        if (checksTable != null) {
+            List<TranslationCheck> loaded = new ArrayList<>();
+            for (String key : checksTable.keySet()) {
+                TomlTable checkTable = checksTable.getTable(key);
+                if (checkTable == null) {
+                    continue;
+                }
+
+                String name = checkTable.getString("name");
+                String translationKey = checkTable.getString("translation_key");
+                if (name == null || translationKey == null) {
+                    continue;
+                }
+
+                Boolean bypass = checkTable.getBoolean("bypass_protection");
+                boolean bypassProtection = bypass != null && bypass;
+
+                List<Action> actions = resolveActions(checkTable.getArray("actions"));
+
+                loaded.add(new TranslationCheck(key, name, translationKey, bypassProtection, actions));
+            }
+            checks = Collections.unmodifiableList(loaded);
+        }
+    }
+
+    private static List<Action> resolveActions(@Nullable TomlArray array) {
+        if (array == null) {
+            return Collections.emptyList();
+        }
+        List<Action> actions = new ArrayList<>();
+        for (Object value : array.toList()) {
+            if (!(value instanceof String actionName)) {
+                continue;
+            }
+            Action action = HackedServer.getAction(actionName);
+            if (action != null) {
+                actions.add(action);
+            }
+        }
+        return Collections.unmodifiableList(actions);
+    }
+
+    public static boolean isEnabled() {
+        return enabled;
+    }
+
+    public static long getDelayTicks() {
+        return delayTicks;
+    }
+
+    public static int getSignOffsetY() {
+        return signOffsetY;
+    }
+
+    public static List<TranslationCheck> getChecks() {
+        return checks;
+    }
+}

--- a/hackedserver-core/src/main/java/org/hackedserver/core/probing/ProbingConfig.java
+++ b/hackedserver-core/src/main/java/org/hackedserver/core/probing/ProbingConfig.java
@@ -43,7 +43,7 @@ public final class ProbingConfig {
         if (settings != null) {
             Long delay = settings.getLong("delay_ticks");
             if (delay != null) {
-                delayTicks = delay;
+                delayTicks = Math.max(1L, delay);
             }
             Long offset = settings.getLong("sign_offset_y");
             if (offset != null) {

--- a/hackedserver-core/src/main/java/org/hackedserver/core/probing/TranslationCheck.java
+++ b/hackedserver-core/src/main/java/org/hackedserver/core/probing/TranslationCheck.java
@@ -1,0 +1,60 @@
+package org.hackedserver.core.probing;
+
+import org.hackedserver.core.config.Action;
+
+import java.util.List;
+
+/**
+ * A single translation-based check that detects a mod by probing
+ * whether the client resolves a specific translation key.
+ */
+public final class TranslationCheck {
+
+    private final String id;
+    private final String name;
+    private final String translationKey;
+    private final boolean bypassProtection;
+    private final List<Action> actions;
+
+    public TranslationCheck(String id, String name, String translationKey,
+                            boolean bypassProtection, List<Action> actions) {
+        this.id = id;
+        this.name = name;
+        this.translationKey = translationKey;
+        this.bypassProtection = bypassProtection;
+        this.actions = actions;
+    }
+
+    public String getId() {
+        return id;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public String getTranslationKey() {
+        return translationKey;
+    }
+
+    /**
+     * Whether to wrap the key in a %s substitution to bypass
+     * client-side sign translation protection mixins.
+     */
+    public boolean isBypassProtection() {
+        return bypassProtection;
+    }
+
+    public List<Action> getActions() {
+        return actions;
+    }
+
+    /**
+     * Returns the expected vanilla client response for this check.
+     * A vanilla client cannot resolve mod translation keys, so it returns
+     * the raw key string.
+     */
+    public String getExpectedVanillaResponse() {
+        return translationKey;
+    }
+}

--- a/hackedserver-core/src/main/resources/forge.toml
+++ b/hackedserver-core/src/main/resources/forge.toml
@@ -44,6 +44,13 @@ mods = [
     "wurst",
     "baritone",
     "meteor",
+    "meteor-client",
     "aristois",
     "impact"
 ]
+
+[spoofing]
+# Detect when the client brand doesn't match registered channels
+# e.g., brand claims "vanilla" but registers fabric/forge channels (ServerSpoof)
+enabled = true
+actions = ["alert"]

--- a/hackedserver-core/src/main/resources/generic.toml
+++ b/hackedserver-core/src/main/resources/generic.toml
@@ -164,6 +164,13 @@ message_has = "PLC18"
 name = "PvPLounge Client"
 category = "client"
 
+[meteor_client]
+actions = ["alert"]
+channels = ["REGISTER", "minecraft:register"]
+message_has = "meteor-client"
+name = "Meteor Client"
+category = "client"
+
 [cracked_vape]
 actions = ["alert"]
 channels = ["LOLIMAHCKER"]

--- a/hackedserver-core/src/main/resources/probing.toml
+++ b/hackedserver-core/src/main/resources/probing.toml
@@ -1,5 +1,5 @@
 # Active probing via sign translation vulnerability (MC-265322)
-# Only works on Paper/Spigot servers (requires world access)
+# Works on Paper/Spigot (real sign blocks) and BungeeCord/Velocity (fake client-side packets).
 # Detects mods by exploiting client-side translation key resolution in sign editors
 enabled = true
 
@@ -7,6 +7,7 @@ enabled = true
 # Delay in ticks after player join before probing (20 ticks = 1 second)
 delay_ticks = 40
 # Y offset from player position for sign placement (negative = below)
+# Only applies to Paper/Spigot; proxy platforms use a fixed position near the player.
 sign_offset_y = -5
 
 # Translation checks - each entry detects a specific mod

--- a/hackedserver-core/src/main/resources/probing.toml
+++ b/hackedserver-core/src/main/resources/probing.toml
@@ -1,0 +1,32 @@
+# Active probing via sign translation vulnerability (MC-265322)
+# Only works on Paper/Spigot servers (requires world access)
+# Detects mods by exploiting client-side translation key resolution in sign editors
+enabled = true
+
+[settings]
+# Delay in ticks after player join before probing (20 ticks = 1 second)
+delay_ticks = 40
+# Y offset from player position for sign placement (negative = below)
+sign_offset_y = -5
+
+# Translation checks - each entry detects a specific mod
+# Up to 4 checks per probe cycle (one per sign line)
+#
+# bypass_protection: wraps the key in a %s substitution to evade
+# Meteor's sign translation mixin that strips known keys
+
+[checks.meteor_client]
+name = "Meteor Client"
+translation_key = "key.category.meteor-client.meteor-client"
+bypass_protection = true
+actions = ["alert"]
+
+[checks.wurst]
+name = "Wurst Client"
+translation_key = "key.wurst.zoom"
+actions = ["alert"]
+
+[checks.freecam]
+name = "Freecam"
+translation_key = "key.freecam.toggle"
+actions = ["alert"]

--- a/hackedserver-spigot/src/main/java/org/hackedserver/spigot/HackedServerPlugin.java
+++ b/hackedserver-spigot/src/main/java/org/hackedserver/spigot/HackedServerPlugin.java
@@ -30,6 +30,8 @@ public class HackedServerPlugin extends JavaPlugin {
     private PacketEventsIntegration packetEventsIntegration;
     @Nullable
     private LunarApolloListener lunarApolloListener;
+    @Nullable
+    private SignTranslationProber signTranslationProber;
 
     public HackedServerPlugin() throws NoSuchFieldException, IllegalAccessException {
         instance = this;
@@ -118,8 +120,15 @@ public class HackedServerPlugin extends JavaPlugin {
 
         lunarApolloListener = new LunarApolloListener(this);
 
-        // Register sign translation probing (active mod detection)
-        Bukkit.getPluginManager().registerEvents(new SignTranslationProber(), this);
+        // Register sign translation probing (active mod detection via packets)
+        if (packetEventsAvailable) {
+            signTranslationProber = new SignTranslationProber();
+            Bukkit.getPluginManager().registerEvents(signTranslationProber, this);
+            signTranslationProber.register();
+            getLogger().info("Sign translation probing enabled (PacketEvents)");
+        } else {
+            getLogger().warning("Sign translation probing requires PacketEvents - disabled");
+        }
 
         // Try to load commands with CommandAPI (may not be available on all server types)
         try {
@@ -145,6 +154,9 @@ public class HackedServerPlugin extends JavaPlugin {
         }
         if (lunarApolloListener != null) {
             lunarApolloListener.unregister();
+        }
+        if (signTranslationProber != null) {
+            signTranslationProber.unregister();
         }
         HackedServer.clear();
     }

--- a/hackedserver-spigot/src/main/java/org/hackedserver/spigot/HackedServerPlugin.java
+++ b/hackedserver-spigot/src/main/java/org/hackedserver/spigot/HackedServerPlugin.java
@@ -139,13 +139,18 @@ public class HackedServerPlugin extends JavaPlugin {
 
         // Register sign translation probing (active mod detection via packets)
         // Only register when PacketEvents is actually initialized (usePacketEvents or standalone plugin)
+        // SignTranslationProber uses 1.20+ sign APIs (Side, SignSide, Player#openSign)
         boolean packetEventsInitialized = usePacketEvents
                 || Bukkit.getPluginManager().getPlugin("packetevents") != null;
         if (packetEventsAvailable && packetEventsInitialized) {
-            signTranslationProber = new SignTranslationProber();
-            Bukkit.getPluginManager().registerEvents(signTranslationProber, this);
-            signTranslationProber.register();
-            getLogger().info("Sign translation probing enabled (PacketEvents)");
+            if (isSignApiAvailable()) {
+                signTranslationProber = new SignTranslationProber();
+                Bukkit.getPluginManager().registerEvents(signTranslationProber, this);
+                signTranslationProber.register();
+                getLogger().info("Sign translation probing enabled (PacketEvents)");
+            } else {
+                getLogger().info("Sign translation probing requires 1.20+ server APIs - disabled on this version");
+            }
         } else if (!packetEventsAvailable) {
             getLogger().warning("Sign translation probing requires PacketEvents - disabled");
         }
@@ -199,6 +204,19 @@ public class HackedServerPlugin extends JavaPlugin {
         // Also check if the PacketEvents classes are available (could be shaded)
         try {
             Class.forName("com.github.retrooper.packetevents.PacketEvents");
+            return true;
+        } catch (ClassNotFoundException e) {
+            return false;
+        }
+    }
+
+    /**
+     * Check if the 1.20+ sign API (Side, SignSide, Player#openSign) is available.
+     * These classes were added in Bukkit 1.20 and are required by SignTranslationProber.
+     */
+    private boolean isSignApiAvailable() {
+        try {
+            Class.forName("org.bukkit.block.sign.Side");
             return true;
         } catch (ClassNotFoundException e) {
             return false;

--- a/hackedserver-spigot/src/main/java/org/hackedserver/spigot/HackedServerPlugin.java
+++ b/hackedserver-spigot/src/main/java/org/hackedserver/spigot/HackedServerPlugin.java
@@ -137,12 +137,15 @@ public class HackedServerPlugin extends JavaPlugin {
         lunarApolloListener = new LunarApolloListener(this);
 
         // Register sign translation probing (active mod detection via packets)
-        if (packetEventsAvailable) {
+        // Only register when PacketEvents is actually initialized (usePacketEvents or standalone plugin)
+        boolean packetEventsInitialized = usePacketEvents
+                || Bukkit.getPluginManager().getPlugin("packetevents") != null;
+        if (packetEventsAvailable && packetEventsInitialized) {
             signTranslationProber = new SignTranslationProber();
             Bukkit.getPluginManager().registerEvents(signTranslationProber, this);
             signTranslationProber.register();
             getLogger().info("Sign translation probing enabled (PacketEvents)");
-        } else {
+        } else if (!packetEventsAvailable) {
             getLogger().warning("Sign translation probing requires PacketEvents - disabled");
         }
 

--- a/hackedserver-spigot/src/main/java/org/hackedserver/spigot/HackedServerPlugin.java
+++ b/hackedserver-spigot/src/main/java/org/hackedserver/spigot/HackedServerPlugin.java
@@ -140,19 +140,26 @@ public class HackedServerPlugin extends JavaPlugin {
         // Register sign translation probing (active mod detection via packets)
         // Only register when PacketEvents is actually initialized (usePacketEvents or standalone plugin)
         // SignTranslationProber uses 1.20+ sign APIs (Side, SignSide, Player#openSign)
-        boolean packetEventsInitialized = usePacketEvents
-                || Bukkit.getPluginManager().getPlugin("packetevents") != null;
+        boolean packetEventsInitialized = packetEventsIntegration != null
+                && packetEventsIntegration.isReadyForListeners();
         if (packetEventsAvailable && packetEventsInitialized) {
             if (isSignApiAvailable()) {
-                signTranslationProber = new SignTranslationProber();
-                Bukkit.getPluginManager().registerEvents(signTranslationProber, this);
-                signTranslationProber.register();
-                getLogger().info("Sign translation probing enabled (PacketEvents)");
+                try {
+                    signTranslationProber = new SignTranslationProber();
+                    Bukkit.getPluginManager().registerEvents(signTranslationProber, this);
+                    signTranslationProber.register();
+                    getLogger().info("Sign translation probing enabled (PacketEvents)");
+                } catch (Throwable e) {
+                    signTranslationProber = null;
+                    getLogger().warning("Failed to register sign translation probing: " + e.getMessage());
+                }
             } else {
                 getLogger().info("Sign translation probing requires 1.20+ server APIs - disabled on this version");
             }
         } else if (!packetEventsAvailable) {
             getLogger().warning("Sign translation probing requires PacketEvents - disabled");
+        } else {
+            getLogger().warning("Sign translation probing requires an initialized PacketEvents API - disabled");
         }
 
         // Try to load commands with CommandAPI, fall back to Bukkit commands if unavailable

--- a/hackedserver-spigot/src/main/java/org/hackedserver/spigot/HackedServerPlugin.java
+++ b/hackedserver-spigot/src/main/java/org/hackedserver/spigot/HackedServerPlugin.java
@@ -66,6 +66,22 @@ public class HackedServerPlugin extends JavaPlugin {
         // Check if ProtocolLib is available
         protocolLibAvailable = Bukkit.getPluginManager().getPlugin("ProtocolLib") != null;
 
+        // Re-check PacketEvents availability during onEnable() if not found during onLoad()
+        // Paper's new plugin system may not have loaded packetevents' classes during our onLoad()
+        if (!packetEventsAvailable) {
+            packetEventsAvailable = isPacketEventsPresent();
+            if (packetEventsAvailable) {
+                try {
+                    packetEventsIntegration = new PacketEventsIntegration(this);
+                    packetEventsIntegration.load();
+                } catch (Throwable e) {
+                    getLogger().warning("Failed to initialize PacketEvents: " + e.getMessage());
+                    packetEventsAvailable = false;
+                    packetEventsIntegration = null;
+                }
+            }
+        }
+
         // Determine which packet library to use
         // Prefer ProtocolLib on standard Paper/Spigot, use PacketEvents on hybrid servers like Arclight
         boolean useProtocolLib = protocolLibAvailable && !isHybridServer();

--- a/hackedserver-spigot/src/main/java/org/hackedserver/spigot/HackedServerPlugin.java
+++ b/hackedserver-spigot/src/main/java/org/hackedserver/spigot/HackedServerPlugin.java
@@ -12,6 +12,7 @@ import org.hackedserver.spigot.commands.CommandsManager;
 import org.hackedserver.spigot.hopper.HackedServerHopper;
 import org.hackedserver.spigot.listeners.HackedPlayerListeners;
 import org.hackedserver.spigot.listeners.LunarApolloListener;
+import org.hackedserver.spigot.probing.SignTranslationProber;
 import org.hackedserver.spigot.protocol.PacketEventsIntegration;
 import org.hackedserver.spigot.protocol.ProtocolLibIntegration;
 import org.hackedserver.spigot.utils.logs.Logs;
@@ -116,6 +117,9 @@ public class HackedServerPlugin extends JavaPlugin {
         }
 
         lunarApolloListener = new LunarApolloListener(this);
+
+        // Register sign translation probing (active mod detection)
+        Bukkit.getPluginManager().registerEvents(new SignTranslationProber(), this);
 
         // Try to load commands with CommandAPI (may not be available on all server types)
         try {

--- a/hackedserver-spigot/src/main/java/org/hackedserver/spigot/HackedServerPlugin.java
+++ b/hackedserver-spigot/src/main/java/org/hackedserver/spigot/HackedServerPlugin.java
@@ -8,6 +8,7 @@ import org.hackedserver.core.HackedServer;
 import org.hackedserver.core.bedrock.BedrockDetector;
 import org.hackedserver.core.config.ConfigsManager;
 import org.hackedserver.core.config.Message;
+import org.hackedserver.spigot.commands.BukkitCommandFallback;
 import org.hackedserver.spigot.commands.CommandsManager;
 import org.hackedserver.spigot.hopper.HackedServerHopper;
 import org.hackedserver.spigot.listeners.HackedPlayerListeners;
@@ -149,14 +150,21 @@ public class HackedServerPlugin extends JavaPlugin {
             getLogger().warning("Sign translation probing requires PacketEvents - disabled");
         }
 
-        // Try to load commands with CommandAPI (may not be available on all server types)
+        // Try to load commands with CommandAPI, fall back to Bukkit commands if unavailable
+        boolean commandsRegistered = false;
         try {
             new CommandsManager(this, audiences).loadCommands();
+            commandsRegistered = true;
         } catch (LinkageError e) {
-            // Catches NoClassDefFoundError, IncompatibleClassChangeError, etc.
-            getLogger().warning("CommandAPI is not available - commands will not be registered.");
-            getLogger().warning("This is expected on non-Paper servers like Arclight/Mohist.");
-            getLogger().info("The plugin will function normally without command support.");
+            // CommandAPI not available - will use Bukkit fallback below
+        }
+        if (!commandsRegistered) {
+            BukkitCommandFallback fallback = new BukkitCommandFallback(this, audiences);
+            var cmd = getCommand("hackedserver");
+            if (cmd != null) {
+                cmd.setExecutor(fallback);
+                cmd.setTabCompleter(fallback);
+            }
         }
         Logs.logComponent(Message.PLUGIN_LOADED.toComponent());
 

--- a/hackedserver-spigot/src/main/java/org/hackedserver/spigot/commands/BukkitCommandFallback.java
+++ b/hackedserver-spigot/src/main/java/org/hackedserver/spigot/commands/BukkitCommandFallback.java
@@ -1,0 +1,190 @@
+package org.hackedserver.spigot.commands;
+
+import net.kyori.adventure.platform.bukkit.BukkitAudiences;
+import net.kyori.adventure.text.minimessage.tag.resolver.Placeholder;
+import org.bukkit.Bukkit;
+import org.bukkit.command.Command;
+import org.bukkit.command.CommandExecutor;
+import org.bukkit.command.CommandSender;
+import org.bukkit.command.TabCompleter;
+import org.bukkit.entity.Player;
+import org.bukkit.plugin.java.JavaPlugin;
+import org.hackedserver.core.HackedPlayer;
+import org.hackedserver.core.HackedServer;
+import org.hackedserver.core.config.ConfigsManager;
+import org.hackedserver.core.config.LunarConfig;
+import org.hackedserver.core.config.Message;
+import org.hackedserver.core.forge.ForgeConfig;
+import org.hackedserver.core.forge.ForgeModInfo;
+import org.hackedserver.core.lunar.LunarModInfo;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.stream.Collectors;
+
+/**
+ * Fallback Bukkit command handler used when CommandAPI is not available.
+ */
+public class BukkitCommandFallback implements CommandExecutor, TabCompleter {
+
+    private static final List<String> SUBCOMMANDS = Arrays.asList("reload", "check", "list", "inv");
+
+    private final JavaPlugin plugin;
+    private final BukkitAudiences audiences;
+
+    public BukkitCommandFallback(JavaPlugin plugin, BukkitAudiences audiences) {
+        this.plugin = plugin;
+        this.audiences = audiences;
+    }
+
+    @Override
+    public boolean onCommand(CommandSender sender, Command command, String label, String[] args) {
+        if (!sender.hasPermission("hackedserver.command")) {
+            return true;
+        }
+
+        if (args.length == 0) {
+            Message.COMMANDS_HELP_SPIGOT.send(audiences.sender(sender));
+            return true;
+        }
+
+        switch (args[0].toLowerCase()) {
+            case "reload" -> handleReload(sender);
+            case "check" -> handleCheck(sender, args);
+            case "list" -> handleList(sender);
+            case "inv" -> handleInv(sender);
+            default -> Message.COMMANDS_HELP_SPIGOT.send(audiences.sender(sender));
+        }
+
+        return true;
+    }
+
+    private void handleReload(CommandSender sender) {
+        if (!sender.hasPermission("hackedserver.command.reload")) return;
+        ConfigsManager.reload(plugin.getDataFolder());
+        Bukkit.getOnlinePlayers().forEach(player -> HackedServer.registerPlayer(player.getUniqueId()));
+        Message.COMMANDS_RELOAD_SUCCESS.send(audiences.sender(sender));
+    }
+
+    private void handleCheck(CommandSender sender, String[] args) {
+        if (!sender.hasPermission("hackedserver.command.check")) return;
+        if (args.length < 2) {
+            audiences.sender(sender).sendMessage(
+                    net.kyori.adventure.text.Component.text("Usage: /hackedserver check <player>"));
+            return;
+        }
+        Player player = Bukkit.getPlayer(args[1]);
+        if (player == null) {
+            audiences.sender(sender).sendMessage(
+                    net.kyori.adventure.text.Component.text("Player not found: " + args[1]));
+            return;
+        }
+
+        HackedPlayer hackedPlayer = HackedServer.getPlayer(player.getUniqueId());
+        boolean hasGenericChecks = !hackedPlayer.getGenericChecks().isEmpty();
+        boolean showLunarMods = LunarConfig.isEnabled()
+                && LunarConfig.shouldShowModsInCheck()
+                && hackedPlayer.hasLunarModsData();
+        boolean hasLunarMods = showLunarMods && !hackedPlayer.getLunarMods().isEmpty();
+
+        if (hasGenericChecks) {
+            Message.CHECK_MODS.send(audiences.sender(sender));
+            hackedPlayer.getGenericChecks().forEach(checkId -> {
+                var check = HackedServer.getCheck(checkId);
+                String modName = check != null ? check.getName() : checkId;
+                Message.MOD_LIST_FORMAT.send(audiences.sender(sender),
+                        Placeholder.parsed("mod", modName));
+            });
+        } else if (!showLunarMods) {
+            Message.CHECK_NO_MODS.send(audiences.sender(sender));
+        }
+
+        if (showLunarMods) {
+            if (hasLunarMods) {
+                Message.CHECK_LUNAR_MODS.send(audiences.sender(sender));
+                for (LunarModInfo mod : hackedPlayer.getLunarMods()) {
+                    Message.LUNAR_MOD_LIST_FORMAT.send(audiences.sender(sender),
+                            Placeholder.parsed("mod", LunarConfig.formatMod(mod)));
+                }
+            } else {
+                Message.CHECK_LUNAR_NO_MODS.send(audiences.sender(sender));
+            }
+        }
+
+        // Display Forge mods
+        boolean showForgeMods = ForgeConfig.isEnabled()
+                && ForgeConfig.shouldShowModsInCheck()
+                && hackedPlayer.hasForgeModsData();
+        boolean hasForgeMods = showForgeMods && !hackedPlayer.getForgeMods().isEmpty();
+
+        if (showForgeMods) {
+            if (hasForgeMods) {
+                Message.CHECK_FORGE_MODS.send(audiences.sender(sender));
+                for (ForgeModInfo mod : hackedPlayer.getForgeMods()) {
+                    Message.FORGE_MOD_LIST_FORMAT.send(audiences.sender(sender),
+                            Placeholder.parsed("mod", ForgeConfig.formatMod(mod)));
+                }
+            } else {
+                Message.CHECK_FORGE_NO_MODS.send(audiences.sender(sender));
+            }
+        }
+    }
+
+    private void handleList(CommandSender sender) {
+        if (!sender.hasPermission("hackedserver.command.list")) return;
+        var playersWithChecks = HackedServer.getPlayers().stream()
+                .filter(player -> !player.getGenericChecks().isEmpty())
+                .collect(Collectors.toList());
+
+        if (playersWithChecks.isEmpty()) {
+            Message.CHECK_PLAYERS_EMPTY.send(audiences.sender(sender));
+            return;
+        }
+
+        Message.CHECK_PLAYERS.send(audiences.sender(sender));
+        playersWithChecks.forEach(hackedPlayer -> {
+            Message.PLAYER_LIST_FORMAT.send(audiences.sender(sender),
+                    Placeholder.parsed("player",
+                            java.util.Objects.requireNonNull(
+                                    Bukkit.getOfflinePlayer(hackedPlayer.getUuid()).getName())));
+        });
+    }
+
+    private void handleInv(CommandSender sender) {
+        if (!sender.hasPermission("hackedserver.command.inv")) return;
+        if (!(sender instanceof Player player)) {
+            audiences.sender(sender).sendMessage(
+                    net.kyori.adventure.text.Component.text("This command can only be used by players."));
+            return;
+        }
+        CommandsManager.openInvPage(player, 0);
+    }
+
+    @Override
+    public List<String> onTabComplete(CommandSender sender, Command command, String alias, String[] args) {
+        if (!sender.hasPermission("hackedserver.command")) {
+            return Collections.emptyList();
+        }
+
+        if (args.length == 1) {
+            String prefix = args[0].toLowerCase();
+            return SUBCOMMANDS.stream()
+                    .filter(sub -> sub.startsWith(prefix))
+                    .filter(sub -> sender.hasPermission("hackedserver.command." + sub))
+                    .collect(Collectors.toList());
+        }
+
+        if (args.length == 2 && "check".equalsIgnoreCase(args[0])) {
+            if (!sender.hasPermission("hackedserver.command.check")) return Collections.emptyList();
+            String prefix = args[1].toLowerCase();
+            return Bukkit.getOnlinePlayers().stream()
+                    .map(Player::getName)
+                    .filter(name -> name.toLowerCase().startsWith(prefix))
+                    .collect(Collectors.toList());
+        }
+
+        return Collections.emptyList();
+    }
+}

--- a/hackedserver-spigot/src/main/java/org/hackedserver/spigot/commands/BukkitCommandFallback.java
+++ b/hackedserver-spigot/src/main/java/org/hackedserver/spigot/commands/BukkitCommandFallback.java
@@ -17,6 +17,7 @@ import org.hackedserver.core.config.Message;
 import org.hackedserver.core.forge.ForgeConfig;
 import org.hackedserver.core.forge.ForgeModInfo;
 import org.hackedserver.core.lunar.LunarModInfo;
+import org.hackedserver.spigot.utils.HackedInventoryView;
 
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -147,8 +148,9 @@ public class BukkitCommandFallback implements CommandExecutor, TabCompleter {
         playersWithChecks.forEach(hackedPlayer -> {
             Message.PLAYER_LIST_FORMAT.send(audiences.sender(sender),
                     Placeholder.parsed("player",
-                            java.util.Objects.requireNonNull(
-                                    Bukkit.getOfflinePlayer(hackedPlayer.getUuid()).getName())));
+                            java.util.Objects.requireNonNullElse(
+                                    Bukkit.getOfflinePlayer(hackedPlayer.getUuid()).getName(),
+                                    hackedPlayer.getUuid().toString())));
         });
     }
 
@@ -159,7 +161,7 @@ public class BukkitCommandFallback implements CommandExecutor, TabCompleter {
                     net.kyori.adventure.text.Component.text("This command can only be used by players."));
             return;
         }
-        CommandsManager.openInvPage(player, 0);
+        HackedInventoryView.openInvPage(player, 0);
     }
 
     @Override

--- a/hackedserver-spigot/src/main/java/org/hackedserver/spigot/commands/CommandsManager.java
+++ b/hackedserver-spigot/src/main/java/org/hackedserver/spigot/commands/CommandsManager.java
@@ -4,42 +4,23 @@ import dev.jorel.commandapi.CommandAPICommand;
 import dev.jorel.commandapi.arguments.EntitySelectorArgument;
 import net.kyori.adventure.platform.bukkit.BukkitAudiences;
 import net.kyori.adventure.text.minimessage.tag.resolver.Placeholder;
-import net.kyori.adventure.text.Component;
-import net.kyori.adventure.text.format.NamedTextColor;
-import net.kyori.adventure.text.format.TextDecoration;
-import net.kyori.adventure.text.serializer.legacy.LegacyComponentSerializer;
 import org.bukkit.Bukkit;
-import org.bukkit.Material;
 import org.bukkit.entity.Player;
-import org.bukkit.inventory.Inventory;
-import org.bukkit.inventory.ItemStack;
-import org.bukkit.inventory.meta.ItemMeta;
-import org.bukkit.inventory.meta.SkullMeta;
 import org.bukkit.plugin.java.JavaPlugin;
 import org.hackedserver.core.HackedPlayer;
 import org.hackedserver.core.HackedServer;
 import org.hackedserver.core.config.ConfigsManager;
-import org.hackedserver.core.config.LunarConfig;
-import org.hackedserver.core.config.GenericCheck;
 import org.hackedserver.core.config.Message;
+import org.hackedserver.core.config.LunarConfig;
 import org.hackedserver.core.forge.ForgeConfig;
 import org.hackedserver.core.forge.ForgeModInfo;
 import org.hackedserver.core.lunar.LunarModInfo;
-import org.hackedserver.spigot.HackedHolder;
+import org.hackedserver.spigot.utils.HackedInventoryView;
 
-import java.util.ArrayList;
-import java.util.Comparator;
-import java.util.List;
 import java.util.Objects;
 import java.util.stream.Collectors;
 
 public class CommandsManager {
-
-    private static final int ITEMS_PER_PAGE = 45;
-    private static final int INV_SIZE = 54;
-    private static final int NAV_PREV_SLOT = 45;
-    private static final int NAV_INFO_SLOT = 49;
-    private static final int NAV_NEXT_SLOT = 53;
 
     private final JavaPlugin plugin;
     private final BukkitAudiences audiences;
@@ -142,8 +123,9 @@ public class CommandsManager {
                     playersWithChecks.forEach(hackedPlayer -> {
                         Message.PLAYER_LIST_FORMAT.send(audiences.sender(sender),
                                 Placeholder.parsed("player",
-                                        Objects.requireNonNull(
-                                                Bukkit.getOfflinePlayer(hackedPlayer.getUuid()).getName())));
+                                        Objects.requireNonNullElse(
+                                                Bukkit.getOfflinePlayer(hackedPlayer.getUuid()).getName(),
+                                                hackedPlayer.getUuid().toString())));
                     });
                 });
     }
@@ -157,127 +139,7 @@ public class CommandsManager {
     }
 
     public static void openInvPage(Player viewer, int page) {
-        List<HackedPlayer> players = HackedServer.getPlayers().stream()
-                .sorted(Comparator.comparing(p -> {
-                    String name = Bukkit.getOfflinePlayer(p.getUuid()).getName();
-                    return name != null ? name.toLowerCase() : "";
-                }))
-                .collect(Collectors.toList());
-
-        int totalPages = Math.max(1, (int) Math.ceil((double) players.size() / ITEMS_PER_PAGE));
-        page = Math.max(0, Math.min(page, totalPages - 1));
-
-        HackedHolder holder = new HackedHolder(page);
-        Inventory inv = Bukkit.createInventory(holder, INV_SIZE, "HackedServer");
-        holder.setInventory(inv);
-
-        // Get all checks for categorization
-        List<GenericCheck> loaderChecks = HackedServer.getChecks().stream()
-                .filter(c -> "loader".equals(c.getCategory()))
-                .sorted(Comparator.comparing(GenericCheck::getName))
-                .collect(Collectors.toList());
-
-        int start = page * ITEMS_PER_PAGE;
-        int end = Math.min(start + ITEMS_PER_PAGE, players.size());
-
-        for (int i = start; i < end; i++) {
-            HackedPlayer hackedPlayer = players.get(i);
-            ItemStack head = new ItemStack(Material.PLAYER_HEAD);
-            SkullMeta meta = (SkullMeta) head.getItemMeta();
-            assert meta != null;
-            meta.setOwningPlayer(Bukkit.getOfflinePlayer(hackedPlayer.getUuid()));
-
-            String playerName = Bukkit.getOfflinePlayer(hackedPlayer.getUuid()).getName();
-            if (playerName != null) {
-                meta.setDisplayName(toLegacy(Component.text(playerName, NamedTextColor.WHITE)
-                        .decoration(TextDecoration.ITALIC, false)));
-            }
-
-            List<String> lore = new ArrayList<>();
-
-            // Loader section — show all loader checks with ✓/✗
-            for (GenericCheck loader : loaderChecks) {
-                boolean detected = hackedPlayer.getGenericChecks().contains(loader.getId());
-                if (detected) {
-                    lore.add(toLegacy(Component.text("✓ " + loader.getName() + " detected", NamedTextColor.GREEN)
-                            .decoration(TextDecoration.ITALIC, false)));
-                } else {
-                    lore.add(toLegacy(Component.text("✗ " + loader.getName() + " not detected", NamedTextColor.GRAY)
-                            .decoration(TextDecoration.ITALIC, false)));
-                }
-            }
-
-            // Separator
-            lore.add(toLegacy(Component.text("━━━━━━━━━━━━━━━━━━━━", NamedTextColor.DARK_GRAY)));
-
-            // Non-loader detected checks
-            List<GenericCheck> detectedNonLoader = HackedServer.getChecks().stream()
-                    .filter(check -> hackedPlayer.getGenericChecks().contains(check.getId()))
-                    .filter(check -> !"loader".equals(check.getCategory()))
-                    .sorted(Comparator.comparing(GenericCheck::getName))
-                    .collect(Collectors.toList());
-
-            int totalNonLoader = (int) HackedServer.getChecks().stream()
-                    .filter(check -> !"loader".equals(check.getCategory()))
-                    .count();
-            int cleanCount = totalNonLoader - detectedNonLoader.size();
-
-            if (detectedNonLoader.isEmpty()) {
-                lore.add(toLegacy(Component.text("✓ " + cleanCount + " checks passed", NamedTextColor.GREEN)
-                        .decoration(TextDecoration.ITALIC, false)));
-            } else {
-                for (GenericCheck check : detectedNonLoader) {
-                    lore.add(toLegacy(Component.text("⚠ " + check.getName(), NamedTextColor.YELLOW)
-                            .decoration(TextDecoration.ITALIC, false)));
-                }
-                lore.add(toLegacy(Component.text("")));
-                lore.add(toLegacy(Component.text("✓ " + cleanCount + " other checks passed", NamedTextColor.GREEN)
-                        .decoration(TextDecoration.ITALIC, false)));
-            }
-
-            meta.setLore(lore);
-            head.setItemMeta(meta);
-            inv.setItem(i - start, head);
-        }
-
-        // Navigation bar (bottom row)
-        if (page > 0) {
-            ItemStack prev = new ItemStack(Material.ARROW);
-            ItemMeta prevMeta = prev.getItemMeta();
-            assert prevMeta != null;
-            prevMeta.setDisplayName(toLegacy(Component.text("← Previous Page", NamedTextColor.GOLD)
-                    .decoration(TextDecoration.ITALIC, false)));
-            prev.setItemMeta(prevMeta);
-            inv.setItem(NAV_PREV_SLOT, prev);
-        }
-
-        ItemStack info = new ItemStack(Material.PAPER);
-        ItemMeta infoMeta = info.getItemMeta();
-        assert infoMeta != null;
-        infoMeta.setDisplayName(toLegacy(Component.text("Page " + (page + 1) + "/" + totalPages, NamedTextColor.WHITE)
-                .decoration(TextDecoration.ITALIC, false)));
-        List<String> infoLore = new ArrayList<>();
-        infoLore.add(toLegacy(Component.text(players.size() + " players tracked", NamedTextColor.GRAY)
-                .decoration(TextDecoration.ITALIC, false)));
-        infoMeta.setLore(infoLore);
-        info.setItemMeta(infoMeta);
-        inv.setItem(NAV_INFO_SLOT, info);
-
-        if (page < totalPages - 1) {
-            ItemStack next = new ItemStack(Material.ARROW);
-            ItemMeta nextMeta = next.getItemMeta();
-            assert nextMeta != null;
-            nextMeta.setDisplayName(toLegacy(Component.text("Next Page →", NamedTextColor.GOLD)
-                    .decoration(TextDecoration.ITALIC, false)));
-            next.setItemMeta(nextMeta);
-            inv.setItem(NAV_NEXT_SLOT, next);
-        }
-
-        viewer.openInventory(inv);
-    }
-
-    private static String toLegacy(Component component) {
-        return LegacyComponentSerializer.legacySection().serialize(component);
+        HackedInventoryView.openInvPage(viewer, page);
     }
 
 }

--- a/hackedserver-spigot/src/main/java/org/hackedserver/spigot/listeners/HackedPlayerListeners.java
+++ b/hackedserver-spigot/src/main/java/org/hackedserver/spigot/listeners/HackedPlayerListeners.java
@@ -15,9 +15,9 @@ import org.hackedserver.core.HackedServer;
 import org.hackedserver.core.config.BedrockConfig;
 import org.hackedserver.spigot.HackedHolder;
 import org.hackedserver.spigot.HackedServerPlugin;
-import org.hackedserver.spigot.commands.CommandsManager;
 import org.hackedserver.core.bedrock.BedrockDetector;
 import net.kyori.adventure.text.minimessage.tag.resolver.Placeholder;
+import org.hackedserver.spigot.utils.HackedInventoryView;
 
 import org.hackedserver.core.utils.JoinWebhook;
 
@@ -81,9 +81,9 @@ public class HackedPlayerListeners implements Listener {
 
         Player player = (Player) event.getWhoClicked();
         if (slot == 45 && holder.getPage() > 0) {
-            CommandsManager.openInvPage(player, holder.getPage() - 1);
+            HackedInventoryView.openInvPage(player, holder.getPage() - 1);
         } else if (slot == 53 && inv.getItem(53) != null) {
-            CommandsManager.openInvPage(player, holder.getPage() + 1);
+            HackedInventoryView.openInvPage(player, holder.getPage() + 1);
         }
     }
 

--- a/hackedserver-spigot/src/main/java/org/hackedserver/spigot/listeners/PacketEventsPayloadListener.java
+++ b/hackedserver-spigot/src/main/java/org/hackedserver/spigot/listeners/PacketEventsPayloadListener.java
@@ -26,6 +26,7 @@ import org.hackedserver.core.forge.ForgeConfig;
 import org.hackedserver.core.forge.ForgeHandshakeProcessor;
 import org.hackedserver.core.forge.ForgeHandshakeResult;
 import org.hackedserver.core.forge.ForgeModInfo;
+import org.hackedserver.core.forge.ForgeSpoofingDetector;
 import org.hackedserver.spigot.HackedServerPlugin;
 import org.hackedserver.spigot.utils.logs.Logs;
 
@@ -160,17 +161,13 @@ public class PacketEventsPayloadListener extends PacketListenerAbstract {
     }
 
     private void checkBrandSpoofing(UUID playerUuid, String playerName, HackedPlayer hackedPlayer) {
-        if (ForgeConfig.isSpoofingDetectionEnabled()
-                && !hackedPlayer.hasGenericCheck("spoofed_brand")
-                && ForgeChannelParser.isVanillaBrand(hackedPlayer.getBrand())
-                && hackedPlayer.hasFabricChannelsDetected()) {
-            hackedPlayer.addGenericCheck("spoofed_brand");
+        if (ForgeSpoofingDetector.detect(hackedPlayer)) {
             List<Action> actions = ForgeConfig.getSpoofingActions();
             if (!actions.isEmpty()) {
                 for (Action action : actions) {
-                    performActions(action, playerUuid, playerName, "Spoofed Brand (Fabric)",
+                    performActions(action, playerUuid, playerName, ForgeSpoofingDetector.CHECK_NAME,
                             Placeholder.unparsed("player", playerName),
-                            Placeholder.parsed("name", "Spoofed Brand (Fabric)"));
+                            Placeholder.parsed("name", ForgeSpoofingDetector.CHECK_NAME));
                 }
             }
         }

--- a/hackedserver-spigot/src/main/java/org/hackedserver/spigot/listeners/PacketEventsPayloadListener.java
+++ b/hackedserver-spigot/src/main/java/org/hackedserver/spigot/listeners/PacketEventsPayloadListener.java
@@ -125,6 +125,7 @@ public class PacketEventsPayloadListener extends PacketListenerAbstract {
     private void processForgePacket(UUID playerUuid, String playerName, HackedPlayer hackedPlayer, String channel, String message) {
         // Detect client type from minecraft:brand
         if (ForgeChannelParser.BRAND_CHANNEL.equalsIgnoreCase(channel)) {
+            hackedPlayer.setBrand(message);
             ForgeClientType clientType = ForgeChannelParser.parseClientType(message);
             if (clientType != null && hackedPlayer.getForgeClientType() == null) {
                 hackedPlayer.setForgeClientType(clientType);
@@ -142,6 +143,22 @@ public class PacketEventsPayloadListener extends PacketListenerAbstract {
                 ForgeHandshakeResult result = ForgeHandshakeProcessor.processMods(hackedPlayer, mods);
                 if (result.hasTriggers()) {
                     runForgeActions(result.getTriggers(), playerUuid, playerName);
+                }
+            }
+
+            // Brand spoofing detection: vanilla brand + fabric channels = ServerSpoof
+            if (ForgeConfig.isSpoofingDetectionEnabled()
+                    && !hackedPlayer.hasGenericCheck("spoofed_brand")
+                    && ForgeChannelParser.isVanillaBrand(hackedPlayer.getBrand())
+                    && ForgeChannelParser.containsFabricChannels(message)) {
+                hackedPlayer.addGenericCheck("spoofed_brand");
+                List<Action> actions = ForgeConfig.getSpoofingActions();
+                if (!actions.isEmpty()) {
+                    for (Action action : actions) {
+                        performActions(action, playerUuid, playerName, "Spoofed Brand (Fabric)",
+                                Placeholder.unparsed("player", playerName),
+                                Placeholder.parsed("name", "Spoofed Brand (Fabric)"));
+                    }
                 }
             }
         }

--- a/hackedserver-spigot/src/main/java/org/hackedserver/spigot/listeners/PacketEventsPayloadListener.java
+++ b/hackedserver-spigot/src/main/java/org/hackedserver/spigot/listeners/PacketEventsPayloadListener.java
@@ -134,6 +134,9 @@ public class PacketEventsPayloadListener extends PacketListenerAbstract {
                     runForgeActions(result.getTriggers(), playerUuid, playerName);
                 }
             }
+
+            // Re-evaluate spoofing: brand arrived after register
+            checkBrandSpoofing(playerUuid, playerName, hackedPlayer);
         }
 
         // Detect mods from minecraft:register
@@ -146,19 +149,28 @@ public class PacketEventsPayloadListener extends PacketListenerAbstract {
                 }
             }
 
+            // Track fabric channels for deferred spoofing check
+            if (ForgeChannelParser.containsFabricChannels(message)) {
+                hackedPlayer.setFabricChannelsDetected(true);
+            }
+
             // Brand spoofing detection: vanilla brand + fabric channels = ServerSpoof
-            if (ForgeConfig.isSpoofingDetectionEnabled()
-                    && !hackedPlayer.hasGenericCheck("spoofed_brand")
-                    && ForgeChannelParser.isVanillaBrand(hackedPlayer.getBrand())
-                    && ForgeChannelParser.containsFabricChannels(message)) {
-                hackedPlayer.addGenericCheck("spoofed_brand");
-                List<Action> actions = ForgeConfig.getSpoofingActions();
-                if (!actions.isEmpty()) {
-                    for (Action action : actions) {
-                        performActions(action, playerUuid, playerName, "Spoofed Brand (Fabric)",
-                                Placeholder.unparsed("player", playerName),
-                                Placeholder.parsed("name", "Spoofed Brand (Fabric)"));
-                    }
+            checkBrandSpoofing(playerUuid, playerName, hackedPlayer);
+        }
+    }
+
+    private void checkBrandSpoofing(UUID playerUuid, String playerName, HackedPlayer hackedPlayer) {
+        if (ForgeConfig.isSpoofingDetectionEnabled()
+                && !hackedPlayer.hasGenericCheck("spoofed_brand")
+                && ForgeChannelParser.isVanillaBrand(hackedPlayer.getBrand())
+                && hackedPlayer.hasFabricChannelsDetected()) {
+            hackedPlayer.addGenericCheck("spoofed_brand");
+            List<Action> actions = ForgeConfig.getSpoofingActions();
+            if (!actions.isEmpty()) {
+                for (Action action : actions) {
+                    performActions(action, playerUuid, playerName, "Spoofed Brand (Fabric)",
+                            Placeholder.unparsed("player", playerName),
+                            Placeholder.parsed("name", "Spoofed Brand (Fabric)"));
                 }
             }
         }

--- a/hackedserver-spigot/src/main/java/org/hackedserver/spigot/listeners/PayloadProcessor.java
+++ b/hackedserver-spigot/src/main/java/org/hackedserver/spigot/listeners/PayloadProcessor.java
@@ -92,6 +92,7 @@ public final class PayloadProcessor {
     private static void processForgePacket(Player player, HackedPlayer hackedPlayer, String channel, String message) {
         // Detect client type from minecraft:brand
         if (ForgeChannelParser.BRAND_CHANNEL.equalsIgnoreCase(channel)) {
+            hackedPlayer.setBrand(message);
             ForgeClientType clientType = ForgeChannelParser.parseClientType(message);
             if (clientType != null && hackedPlayer.getForgeClientType() == null) {
                 hackedPlayer.setForgeClientType(clientType);
@@ -109,6 +110,18 @@ public final class PayloadProcessor {
                 ForgeHandshakeResult result = ForgeHandshakeProcessor.processMods(hackedPlayer, mods);
                 if (result.hasTriggers()) {
                     runForgeActions(result.getTriggers(), player);
+                }
+            }
+
+            // Brand spoofing detection: vanilla brand + fabric channels = ServerSpoof
+            if (ForgeConfig.isSpoofingDetectionEnabled()
+                    && !hackedPlayer.hasGenericCheck("spoofed_brand")
+                    && ForgeChannelParser.isVanillaBrand(hackedPlayer.getBrand())
+                    && ForgeChannelParser.containsFabricChannels(message)) {
+                hackedPlayer.addGenericCheck("spoofed_brand");
+                List<Action> actions = ForgeConfig.getSpoofingActions();
+                if (!actions.isEmpty()) {
+                    runActions(player, "Spoofed Brand (Fabric)", actions);
                 }
             }
         }

--- a/hackedserver-spigot/src/main/java/org/hackedserver/spigot/listeners/PayloadProcessor.java
+++ b/hackedserver-spigot/src/main/java/org/hackedserver/spigot/listeners/PayloadProcessor.java
@@ -17,6 +17,7 @@ import org.hackedserver.core.forge.ForgeConfig;
 import org.hackedserver.core.forge.ForgeHandshakeProcessor;
 import org.hackedserver.core.forge.ForgeHandshakeResult;
 import org.hackedserver.core.forge.ForgeModInfo;
+import org.hackedserver.core.forge.ForgeSpoofingDetector;
 import org.hackedserver.spigot.HackedServerPlugin;
 import org.hackedserver.spigot.utils.logs.Logs;
 
@@ -127,14 +128,10 @@ public final class PayloadProcessor {
     }
 
     private static void checkBrandSpoofing(Player player, HackedPlayer hackedPlayer) {
-        if (ForgeConfig.isSpoofingDetectionEnabled()
-                && !hackedPlayer.hasGenericCheck("spoofed_brand")
-                && ForgeChannelParser.isVanillaBrand(hackedPlayer.getBrand())
-                && hackedPlayer.hasFabricChannelsDetected()) {
-            hackedPlayer.addGenericCheck("spoofed_brand");
+        if (ForgeSpoofingDetector.detect(hackedPlayer)) {
             List<Action> actions = ForgeConfig.getSpoofingActions();
             if (!actions.isEmpty()) {
-                runActions(player, "Spoofed Brand (Fabric)", actions);
+                runActions(player, ForgeSpoofingDetector.CHECK_NAME, actions);
             }
         }
     }

--- a/hackedserver-spigot/src/main/java/org/hackedserver/spigot/listeners/PayloadProcessor.java
+++ b/hackedserver-spigot/src/main/java/org/hackedserver/spigot/listeners/PayloadProcessor.java
@@ -101,6 +101,9 @@ public final class PayloadProcessor {
                     runForgeActions(result.getTriggers(), player);
                 }
             }
+
+            // Re-evaluate spoofing: brand arrived after register
+            checkBrandSpoofing(player, hackedPlayer);
         }
 
         // Detect mods from minecraft:register
@@ -113,16 +116,25 @@ public final class PayloadProcessor {
                 }
             }
 
+            // Track fabric channels for deferred spoofing check
+            if (ForgeChannelParser.containsFabricChannels(message)) {
+                hackedPlayer.setFabricChannelsDetected(true);
+            }
+
             // Brand spoofing detection: vanilla brand + fabric channels = ServerSpoof
-            if (ForgeConfig.isSpoofingDetectionEnabled()
-                    && !hackedPlayer.hasGenericCheck("spoofed_brand")
-                    && ForgeChannelParser.isVanillaBrand(hackedPlayer.getBrand())
-                    && ForgeChannelParser.containsFabricChannels(message)) {
-                hackedPlayer.addGenericCheck("spoofed_brand");
-                List<Action> actions = ForgeConfig.getSpoofingActions();
-                if (!actions.isEmpty()) {
-                    runActions(player, "Spoofed Brand (Fabric)", actions);
-                }
+            checkBrandSpoofing(player, hackedPlayer);
+        }
+    }
+
+    private static void checkBrandSpoofing(Player player, HackedPlayer hackedPlayer) {
+        if (ForgeConfig.isSpoofingDetectionEnabled()
+                && !hackedPlayer.hasGenericCheck("spoofed_brand")
+                && ForgeChannelParser.isVanillaBrand(hackedPlayer.getBrand())
+                && hackedPlayer.hasFabricChannelsDetected()) {
+            hackedPlayer.addGenericCheck("spoofed_brand");
+            List<Action> actions = ForgeConfig.getSpoofingActions();
+            if (!actions.isEmpty()) {
+                runActions(player, "Spoofed Brand (Fabric)", actions);
             }
         }
     }

--- a/hackedserver-spigot/src/main/java/org/hackedserver/spigot/probing/SignTranslationProber.java
+++ b/hackedserver-spigot/src/main/java/org/hackedserver/spigot/probing/SignTranslationProber.java
@@ -36,6 +36,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.UUID;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.atomic.AtomicBoolean;
 
 /**
  * Active probing via the sign translation vulnerability (MC-265322).
@@ -63,7 +64,7 @@ public class SignTranslationProber implements Listener {
         private final BlockState originalBlockState;
         private final List<TranslationCheck> lineChecks;
         private volatile boolean timedOut = false;
-        private volatile boolean handled = false;
+        private final AtomicBoolean handled = new AtomicBoolean(false);
 
         ProbeSession(Location signLocation, BlockData originalBlockData, BlockState originalBlockState, List<TranslationCheck> lineChecks) {
             this.signLocation = signLocation;
@@ -152,8 +153,15 @@ public class SignTranslationProber implements Listener {
     @EventHandler(priority = EventPriority.LOWEST)
     public void onSignChange(SignChangeEvent event) {
         Player player = event.getPlayer();
-        if (activeSessions.containsKey(player.getUniqueId())) {
-            event.setCancelled(true);
+        ProbeSession session = activeSessions.get(player.getUniqueId());
+        if (session != null) {
+            Location probeLoc = session.signLocation();
+            Location signLoc = event.getBlock().getLocation();
+            if (signLoc.getBlockX() == probeLoc.getBlockX()
+                    && signLoc.getBlockY() == probeLoc.getBlockY()
+                    && signLoc.getBlockZ() == probeLoc.getBlockZ()) {
+                event.setCancelled(true);
+            }
         }
     }
 
@@ -250,7 +258,7 @@ public class SignTranslationProber implements Listener {
                 // Timeout: restore block but keep session for late packet arrivals
                 Bukkit.getScheduler().runTaskLater(HackedServerPlugin.get(), () -> {
                     ProbeSession s = activeSessions.get(player.getUniqueId());
-                    if (s != null && !s.handled) {
+                    if (s != null && !s.handled.get()) {
                         s.timedOut = true;
                         if (Config.DEBUG.toBool()) {
                             Logs.logInfo("HackedServer | Sign probe timed out for " + player.getName() + " (waiting for late packet)");
@@ -262,7 +270,7 @@ public class SignTranslationProber implements Listener {
                 // Final cleanup: remove session after grace period for late packets
                 Bukkit.getScheduler().runTaskLater(HackedServerPlugin.get(), () -> {
                     ProbeSession s = activeSessions.remove(player.getUniqueId());
-                    if (s != null && !s.handled) {
+                    if (s != null && !s.handled.get()) {
                         if (Config.DEBUG.toBool()) {
                             Logs.logInfo("HackedServer | Sign probe final cleanup for " + player.getName());
                         }
@@ -284,7 +292,7 @@ public class SignTranslationProber implements Listener {
         UUID playerUUID = event.getUser().getUUID();
 
         ProbeSession session = activeSessions.get(playerUUID);
-        if (session == null || session.handled) {
+        if (session == null || session.handled.get()) {
             return;
         }
 
@@ -297,9 +305,11 @@ public class SignTranslationProber implements Listener {
             return;
         }
 
-        // Now consume the session
+        // Atomically claim the session to avoid race with timeout handler
+        if (!session.handled.compareAndSet(false, true)) {
+            return;
+        }
         activeSessions.remove(playerUUID);
-        session.handled = true;
 
         event.setCancelled(true);
 
@@ -360,8 +370,8 @@ public class SignTranslationProber implements Listener {
             if (session.originalBlockState() != null) {
                 session.originalBlockState().update(true, false);
             }
-        } catch (Throwable e) {
-            // Best effort
+        } catch (Exception e) {
+            Logs.logWarning("Failed to restore block after probe: " + e.getMessage());
         }
     }
 

--- a/hackedserver-spigot/src/main/java/org/hackedserver/spigot/probing/SignTranslationProber.java
+++ b/hackedserver-spigot/src/main/java/org/hackedserver/spigot/probing/SignTranslationProber.java
@@ -60,18 +60,21 @@ public class SignTranslationProber implements Listener {
     private static final class ProbeSession {
         private final Location signLocation;
         private final BlockData originalBlockData;
+        private final BlockState originalBlockState;
         private final List<TranslationCheck> lineChecks;
         private volatile boolean timedOut = false;
         private volatile boolean handled = false;
 
-        ProbeSession(Location signLocation, BlockData originalBlockData, List<TranslationCheck> lineChecks) {
+        ProbeSession(Location signLocation, BlockData originalBlockData, BlockState originalBlockState, List<TranslationCheck> lineChecks) {
             this.signLocation = signLocation;
             this.originalBlockData = originalBlockData;
+            this.originalBlockState = originalBlockState;
             this.lineChecks = lineChecks;
         }
 
         Location signLocation() { return signLocation; }
         BlockData originalBlockData() { return originalBlockData; }
+        BlockState originalBlockState() { return originalBlockState; }
         List<TranslationCheck> lineChecks() { return lineChecks; }
     }
 
@@ -173,6 +176,7 @@ public class SignTranslationProber implements Listener {
         Block block = signLoc.getBlock();
 
         BlockData originalData = block.getBlockData().clone();
+        BlockState originalState = block.getState();
 
         if (Config.DEBUG.toBool()) {
             Logs.logInfo("HackedServer | Starting sign probe for " + player.getName()
@@ -219,7 +223,7 @@ public class SignTranslationProber implements Listener {
 
             // Register the probe session
             activeSessions.put(player.getUniqueId(),
-                    new ProbeSession(signLoc, originalData, lineChecks));
+                    new ProbeSession(signLoc, originalData, originalState, lineChecks));
 
             // Open sign editor after a short delay to let the block update propagate
             Bukkit.getScheduler().runTaskLater(HackedServerPlugin.get(), () -> {
@@ -279,10 +283,22 @@ public class SignTranslationProber implements Listener {
         WrapperPlayClientUpdateSign updateSign = new WrapperPlayClientUpdateSign(event);
         UUID playerUUID = event.getUser().getUUID();
 
-        ProbeSession session = activeSessions.remove(playerUUID);
+        ProbeSession session = activeSessions.get(playerUUID);
         if (session == null || session.handled) {
             return;
         }
+
+        // Verify this UPDATE_SIGN is for the probe sign, not a legitimate sign edit
+        com.github.retrooper.packetevents.util.Vector3i signPos = updateSign.getBlockPosition();
+        Location probeLoc = session.signLocation();
+        if (signPos.x != probeLoc.getBlockX()
+                || signPos.y != probeLoc.getBlockY()
+                || signPos.z != probeLoc.getBlockZ()) {
+            return;
+        }
+
+        // Now consume the session
+        activeSessions.remove(playerUUID);
         session.handled = true;
 
         event.setCancelled(true);
@@ -340,6 +356,10 @@ public class SignTranslationProber implements Listener {
         try {
             Block block = session.signLocation().getBlock();
             block.setBlockData(session.originalBlockData(), false);
+            // Restore tile entity data (chest contents, sign text, etc.)
+            if (session.originalBlockState() != null) {
+                session.originalBlockState().update(true, false);
+            }
         } catch (Throwable e) {
             // Best effort
         }

--- a/hackedserver-spigot/src/main/java/org/hackedserver/spigot/probing/SignTranslationProber.java
+++ b/hackedserver-spigot/src/main/java/org/hackedserver/spigot/probing/SignTranslationProber.java
@@ -319,7 +319,9 @@ public class SignTranslationProber implements Listener {
         if (!session.handled.compareAndSet(false, true)) {
             return;
         }
-        activeSessions.remove(playerUUID);
+        if (!activeSessions.remove(playerUUID, session)) {
+            return;
+        }
 
         event.setCancelled(true);
 

--- a/hackedserver-spigot/src/main/java/org/hackedserver/spigot/probing/SignTranslationProber.java
+++ b/hackedserver-spigot/src/main/java/org/hackedserver/spigot/probing/SignTranslationProber.java
@@ -279,7 +279,7 @@ public class SignTranslationProber implements Listener {
                 }, 440L); // 2 second grace period after timeout
             }, 5L);
 
-        } catch (Throwable e) {
+        } catch (Exception e) {
             Logs.logWarning("Failed to start translation probe: " + e.getMessage());
             ProbeSession s = activeSessions.remove(player.getUniqueId());
             if (s != null) restoreBlock(s);

--- a/hackedserver-spigot/src/main/java/org/hackedserver/spigot/probing/SignTranslationProber.java
+++ b/hackedserver-spigot/src/main/java/org/hackedserver/spigot/probing/SignTranslationProber.java
@@ -32,6 +32,7 @@ import org.hackedserver.spigot.HackedServerPlugin;
 import org.hackedserver.spigot.listeners.PayloadProcessor;
 import org.hackedserver.spigot.utils.logs.Logs;
 
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.UUID;
@@ -63,20 +64,25 @@ public class SignTranslationProber implements Listener {
         private final BlockData originalBlockData;
         private final BlockState originalBlockState;
         private final List<TranslationCheck> lineChecks;
+        private final List<TranslationCheck> remainingChecks;
         private volatile boolean timedOut = false;
         private final AtomicBoolean handled = new AtomicBoolean(false);
+        private final AtomicBoolean restored = new AtomicBoolean(false);
 
-        ProbeSession(Location signLocation, BlockData originalBlockData, BlockState originalBlockState, List<TranslationCheck> lineChecks) {
+        ProbeSession(Location signLocation, BlockData originalBlockData, BlockState originalBlockState,
+                     List<TranslationCheck> lineChecks, List<TranslationCheck> remainingChecks) {
             this.signLocation = signLocation;
             this.originalBlockData = originalBlockData;
             this.originalBlockState = originalBlockState;
             this.lineChecks = lineChecks;
+            this.remainingChecks = remainingChecks;
         }
 
         Location signLocation() { return signLocation; }
         BlockData originalBlockData() { return originalBlockData; }
         BlockState originalBlockState() { return originalBlockState; }
         List<TranslationCheck> lineChecks() { return lineChecks; }
+        List<TranslationCheck> remainingChecks() { return remainingChecks; }
     }
 
     public void register() {
@@ -166,7 +172,10 @@ public class SignTranslationProber implements Listener {
     }
 
     private void startProbe(Player player, List<TranslationCheck> checks) {
-        List<TranslationCheck> lineChecks = checks.size() > 4 ? checks.subList(0, 4) : checks;
+        List<TranslationCheck> lineChecks = new ArrayList<>(checks.subList(0, Math.min(4, checks.size())));
+        List<TranslationCheck> remainingChecks = checks.size() > 4
+                ? new ArrayList<>(checks.subList(4, checks.size()))
+                : List.of();
 
         Location playerLoc = player.getLocation();
         int signX = playerLoc.getBlockX();
@@ -231,7 +240,7 @@ public class SignTranslationProber implements Listener {
 
             // Register the probe session
             activeSessions.put(player.getUniqueId(),
-                    new ProbeSession(signLoc, originalData, originalState, lineChecks));
+                    new ProbeSession(signLoc, originalData, originalState, lineChecks, remainingChecks));
 
             // Open sign editor after a short delay to let the block update propagate
             Bukkit.getScheduler().runTaskLater(HackedServerPlugin.get(), () -> {
@@ -275,6 +284,7 @@ public class SignTranslationProber implements Listener {
                             Logs.logInfo("HackedServer | Sign probe final cleanup for " + player.getName());
                         }
                         restoreBlock(s);
+                        scheduleRemainingChecks(player, s);
                     }
                 }, 440L); // 2 second grace period after timeout
             }, 5L);
@@ -359,10 +369,15 @@ public class SignTranslationProber implements Listener {
                     }
                 }
             }
+
+            scheduleRemainingChecks(onlinePlayer, session);
         });
     }
 
     private void restoreBlock(ProbeSession session) {
+        if (!session.restored.compareAndSet(false, true)) {
+            return;
+        }
         try {
             Block block = session.signLocation().getBlock();
             block.setBlockData(session.originalBlockData(), false);
@@ -373,6 +388,17 @@ public class SignTranslationProber implements Listener {
         } catch (Exception e) {
             Logs.logWarning("Failed to restore block after probe: " + e.getMessage());
         }
+    }
+
+    private void scheduleRemainingChecks(Player player, ProbeSession session) {
+        if (session.remainingChecks().isEmpty() || !player.isOnline()) {
+            return;
+        }
+        Bukkit.getScheduler().runTaskLater(HackedServerPlugin.get(), () -> {
+            if (player.isOnline()) {
+                startProbe(player, session.remainingChecks());
+            }
+        }, 5L);
     }
 
 }

--- a/hackedserver-spigot/src/main/java/org/hackedserver/spigot/probing/SignTranslationProber.java
+++ b/hackedserver-spigot/src/main/java/org/hackedserver/spigot/probing/SignTranslationProber.java
@@ -1,7 +1,12 @@
 package org.hackedserver.spigot.probing;
 
+import com.github.retrooper.packetevents.PacketEvents;
+import com.github.retrooper.packetevents.event.PacketListenerAbstract;
+import com.github.retrooper.packetevents.event.PacketListenerPriority;
+import com.github.retrooper.packetevents.event.PacketReceiveEvent;
+import com.github.retrooper.packetevents.protocol.packettype.PacketType;
+import com.github.retrooper.packetevents.wrapper.play.client.WrapperPlayClientUpdateSign;
 import net.kyori.adventure.text.Component;
-import net.kyori.adventure.text.serializer.plain.PlainTextComponentSerializer;
 import org.bukkit.Bukkit;
 import org.bukkit.Location;
 import org.bukkit.Material;
@@ -20,6 +25,7 @@ import org.bukkit.event.player.PlayerJoinEvent;
 import org.bukkit.event.player.PlayerQuitEvent;
 import org.hackedserver.core.HackedPlayer;
 import org.hackedserver.core.HackedServer;
+import org.hackedserver.core.config.Config;
 import org.hackedserver.core.probing.ProbingConfig;
 import org.hackedserver.core.probing.TranslationCheck;
 import org.hackedserver.spigot.HackedServerPlugin;
@@ -34,26 +40,70 @@ import java.util.concurrent.ConcurrentHashMap;
 /**
  * Active probing via the sign translation vulnerability (MC-265322).
  * <p>
- * Places an invisible sign underground, writes translatable components on it,
- * opens the sign editor for the player, and reads back the resolved text.
- * If the client resolves a mod-specific translation key, the mod is detected.
+ * Places a real sign block in the world with translatable text components
+ * set via the Bukkit Sign API. The server natively serializes these into
+ * the correct NBT format in the BlockEntityData packet. The sign editor
+ * is opened via player.openSign(), and the client's response is intercepted
+ * at the packet level (UPDATE_SIGN) using PacketEvents.
  * <p>
- * Paper 1.20+ only (requires Sign API with Side support).
+ * When the client opens the sign editor, translatable text components are
+ * resolved to plain text. If a mod's translation key resolves to something
+ * other than the raw key, that mod is installed.
+ * <p>
+ * Requires PacketEvents 2.x on the server and Paper (for Adventure API).
  */
 public class SignTranslationProber implements Listener {
 
-    private static final PlainTextComponentSerializer PLAIN = PlainTextComponentSerializer.plainText();
-
-    /**
-     * Tracks active probes: player UUID → probe session data.
-     */
     private final Map<UUID, ProbeSession> activeSessions = new ConcurrentHashMap<>();
+    private PacketListenerAbstract packetListener;
 
-    /**
-     * Stores which checks are assigned to which sign line for each probe.
-     */
-    private record ProbeSession(Location signLocation, BlockData originalBlockData,
-                                List<TranslationCheck> lineChecks) {
+    private static final class ProbeSession {
+        private final Location signLocation;
+        private final BlockData originalBlockData;
+        private final List<TranslationCheck> lineChecks;
+        private volatile boolean timedOut = false;
+        private volatile boolean handled = false;
+
+        ProbeSession(Location signLocation, BlockData originalBlockData, List<TranslationCheck> lineChecks) {
+            this.signLocation = signLocation;
+            this.originalBlockData = originalBlockData;
+            this.lineChecks = lineChecks;
+        }
+
+        Location signLocation() { return signLocation; }
+        BlockData originalBlockData() { return originalBlockData; }
+        List<TranslationCheck> lineChecks() { return lineChecks; }
+    }
+
+    public void register() {
+        packetListener = new PacketListenerAbstract(PacketListenerPriority.LOW) {
+            @Override
+            public void onPacketReceive(PacketReceiveEvent event) {
+                if (event.getPacketType() == PacketType.Play.Client.UPDATE_SIGN) {
+                    if (Config.DEBUG.toBool()) {
+                        WrapperPlayClientUpdateSign dbg = new WrapperPlayClientUpdateSign(event);
+                        UUID uid = event.getUser().getUUID();
+                        boolean hasSession = activeSessions.containsKey(uid);
+                        Logs.logInfo("HackedServer | Received UPDATE_SIGN packet from "
+                                + uid + " (hasSession=" + hasSession + ") lines: [\""
+                                + String.join("\", \"", dbg.getTextLines()) + "\"]");
+                    }
+                    handleUpdateSign(event);
+                }
+            }
+        };
+        PacketEvents.getAPI().getEventManager().registerListener(packetListener);
+    }
+
+    public void unregister() {
+        if (packetListener != null) {
+            PacketEvents.getAPI().getEventManager().unregisterListener(packetListener);
+            packetListener = null;
+        }
+        for (var entry : activeSessions.entrySet()) {
+            restoreBlock(entry.getValue());
+        }
+        activeSessions.clear();
     }
 
     @EventHandler(priority = EventPriority.MONITOR)
@@ -72,7 +122,11 @@ public class SignTranslationProber implements Listener {
             return;
         }
 
-        // Schedule the probe after the configured delay
+        if (Config.DEBUG.toBool()) {
+            Logs.logInfo("HackedServer | Scheduling sign probe for " + player.getName()
+                    + " with " + checks.size() + " checks (delay: " + ProbingConfig.getDelayTicks() + " ticks)");
+        }
+
         Bukkit.getScheduler().runTaskLater(HackedServerPlugin.get(), () -> {
             if (!player.isOnline()) {
                 return;
@@ -86,86 +140,88 @@ public class SignTranslationProber implements Listener {
         ProbeSession session = activeSessions.remove(event.getPlayer().getUniqueId());
         if (session != null) {
             restoreBlock(session);
+            if (Config.DEBUG.toBool()) {
+                Logs.logInfo("HackedServer | Cleaned up probe session for " + event.getPlayer().getName() + " (quit)");
+            }
         }
     }
 
     @EventHandler(priority = EventPriority.LOWEST)
     public void onSignChange(SignChangeEvent event) {
         Player player = event.getPlayer();
-        ProbeSession session = activeSessions.remove(player.getUniqueId());
-        if (session == null) {
-            return;
-        }
-
-        // Cancel the event so the sign is never actually updated in the world
-        event.setCancelled(true);
-
-        // Restore the original block
-        restoreBlock(session);
-
-        // Analyze responses
-        HackedPlayer hackedPlayer = HackedServer.getPlayer(player.getUniqueId());
-
-        for (int i = 0; i < session.lineChecks.size(); i++) {
-            TranslationCheck check = session.lineChecks.get(i);
-            Component lineComponent = event.line(i);
-            String response = PLAIN.serialize(lineComponent).trim();
-            String expected = check.getExpectedVanillaResponse();
-
-            // If the response differs from what vanilla would return, the mod resolved the key
-            if (!response.isEmpty() && !response.equals(expected)) {
-                String probeCheckId = "probe_" + check.getId();
-                if (!hackedPlayer.hasGenericCheck(probeCheckId)) {
-                    hackedPlayer.addGenericCheck(probeCheckId);
-                    PayloadProcessor.runActions(player, check.getName(), check.getActions());
-                }
-            }
+        if (activeSessions.containsKey(player.getUniqueId())) {
+            event.setCancelled(true);
         }
     }
 
     private void startProbe(Player player, List<TranslationCheck> checks) {
-        // Only use up to 4 checks (4 sign lines)
         List<TranslationCheck> lineChecks = checks.size() > 4 ? checks.subList(0, 4) : checks;
 
         Location playerLoc = player.getLocation();
-        Location signLoc = playerLoc.clone().add(0, ProbingConfig.getSignOffsetY(), 0);
+        int signX = playerLoc.getBlockX();
+        int signY = playerLoc.getBlockY() + ProbingConfig.getSignOffsetY();
+        int signZ = playerLoc.getBlockZ();
 
-        // Clamp Y to valid range
-        int minY = signLoc.getWorld().getMinHeight();
-        if (signLoc.getBlockY() < minY) {
-            signLoc.setY(minY);
+        if (playerLoc.getWorld() != null) {
+            int minY = playerLoc.getWorld().getMinHeight();
+            if (signY < minY) {
+                signY = minY;
+            }
         }
 
+        Location signLoc = new Location(playerLoc.getWorld(), signX, signY, signZ);
         Block block = signLoc.getBlock();
-        BlockData originalData = block.getBlockData();
+
+        BlockData originalData = block.getBlockData().clone();
+
+        if (Config.DEBUG.toBool()) {
+            Logs.logInfo("HackedServer | Starting sign probe for " + player.getName()
+                    + " at " + signX + ", " + signY + ", " + signZ);
+        }
+
+        // Place sign block (don't apply physics to avoid breaking it)
+        block.setType(Material.OAK_SIGN, false);
 
         try {
-            // Place sign block
-            block.setType(Material.OAK_SIGN, false);
             BlockState state = block.getState();
             if (!(state instanceof Sign sign)) {
-                // Shouldn't happen, but restore if it does
+                Logs.logWarning("HackedServer | Block at probe location is not a sign for " + player.getName());
                 block.setBlockData(originalData, false);
                 return;
             }
 
-            // Write translation checks on the back side (less visible)
-            Side side = Side.BACK;
-            SignSide signSide = sign.getSide(side);
+            // Set translatable text components on the sign using the Bukkit/Adventure API.
+            // The server will natively serialize these into the correct JSON format
+            // in the BlockEntityData packet sent to the client.
+            SignSide frontSide = sign.getSide(Side.FRONT);
+            for (int i = 0; i < 4; i++) {
+                if (i < lineChecks.size()) {
+                    TranslationCheck check = lineChecks.get(i);
+                    Component line;
+                    if (check.isBypassProtection()) {
+                        // Wrap in %s substitution to bypass Meteor's sign translation mixin
+                        line = Component.translatable("%s", Component.translatable(check.getTranslationKey()));
+                    } else {
+                        line = Component.translatable(check.getTranslationKey());
+                    }
+                    frontSide.line(i, line);
 
-            for (int i = 0; i < lineChecks.size(); i++) {
-                TranslationCheck check = lineChecks.get(i);
-                Component component = buildTranslationComponent(check);
-                signSide.line(i, component);
+                    if (Config.DEBUG.toBool()) {
+                        Logs.logInfo("HackedServer | Set sign line " + i + " to translatable: " + check.getTranslationKey()
+                                + " (bypass=" + check.isBypassProtection() + ")");
+                    }
+                } else {
+                    frontSide.line(i, Component.empty());
+                }
             }
-
+            sign.setWaxed(false);
             sign.update(true, false);
 
-            // Store session
+            // Register the probe session
             activeSessions.put(player.getUniqueId(),
-                    new ProbeSession(signLoc.clone(), originalData, lineChecks));
+                    new ProbeSession(signLoc, originalData, lineChecks));
 
-            // Open sign editor after a short delay (client needs to receive block data first)
+            // Open sign editor after a short delay to let the block update propagate
             Bukkit.getScheduler().runTaskLater(HackedServerPlugin.get(), () -> {
                 if (!player.isOnline()) {
                     ProbeSession s = activeSessions.remove(player.getUniqueId());
@@ -173,55 +229,120 @@ public class SignTranslationProber implements Listener {
                     return;
                 }
 
-                try {
-                    player.openSign(sign, side);
-                } catch (Throwable e) {
-                    Logs.logWarning("Failed to open sign editor for probe: " + e.getMessage());
+                BlockState currentState = block.getState();
+                if (!(currentState instanceof Sign currentSign)) {
+                    Logs.logWarning("HackedServer | Sign disappeared before editor opened for " + player.getName());
                     ProbeSession s = activeSessions.remove(player.getUniqueId());
                     if (s != null) restoreBlock(s);
                     return;
                 }
 
-                // Schedule cleanup in case the client never responds
+                player.openSign(currentSign, Side.FRONT);
+
+                if (Config.DEBUG.toBool()) {
+                    Logs.logInfo("HackedServer | Opened sign editor for " + player.getName());
+                }
+
+                // Timeout: restore block but keep session for late packet arrivals
                 Bukkit.getScheduler().runTaskLater(HackedServerPlugin.get(), () -> {
-                    ProbeSession s = activeSessions.remove(player.getUniqueId());
-                    if (s != null) {
+                    ProbeSession s = activeSessions.get(player.getUniqueId());
+                    if (s != null && !s.handled) {
+                        s.timedOut = true;
+                        if (Config.DEBUG.toBool()) {
+                            Logs.logInfo("HackedServer | Sign probe timed out for " + player.getName() + " (waiting for late packet)");
+                        }
                         restoreBlock(s);
                     }
-                }, 100L); // 5 second timeout
+                }, 400L); // 20 second timeout
+
+                // Final cleanup: remove session after grace period for late packets
+                Bukkit.getScheduler().runTaskLater(HackedServerPlugin.get(), () -> {
+                    ProbeSession s = activeSessions.remove(player.getUniqueId());
+                    if (s != null && !s.handled) {
+                        if (Config.DEBUG.toBool()) {
+                            Logs.logInfo("HackedServer | Sign probe final cleanup for " + player.getName());
+                        }
+                        restoreBlock(s);
+                    }
+                }, 440L); // 2 second grace period after timeout
             }, 5L);
 
         } catch (Throwable e) {
             Logs.logWarning("Failed to start translation probe: " + e.getMessage());
-            block.setBlockData(originalData, false);
+            ProbeSession s = activeSessions.remove(player.getUniqueId());
+            if (s != null) restoreBlock(s);
+            else block.setBlockData(originalData, false);
         }
     }
 
-    /**
-     * Builds the Adventure component for a translation check.
-     * <p>
-     * With bypass_protection: uses %s substitution to wrap the key,
-     * evading client-side mixins that strip known mod keys from signs.
-     * Without: uses a plain translatable component.
-     */
-    private Component buildTranslationComponent(TranslationCheck check) {
-        if (check.isBypassProtection()) {
-            // Wrap in %s to bypass sign translation protection mixins
-            // The outer key "%s" doesn't contain the mod name, so protection doesn't trigger
-            return Component.translatable("%s", Component.translatable(check.getTranslationKey()));
-        } else {
-            return Component.translatable(check.getTranslationKey());
+    private void handleUpdateSign(PacketReceiveEvent event) {
+        WrapperPlayClientUpdateSign updateSign = new WrapperPlayClientUpdateSign(event);
+        UUID playerUUID = event.getUser().getUUID();
+
+        ProbeSession session = activeSessions.remove(playerUUID);
+        if (session == null || session.handled) {
+            return;
         }
+        session.handled = true;
+
+        event.setCancelled(true);
+
+        String[] lines = updateSign.getTextLines();
+
+        if (Config.DEBUG.toBool()) {
+            Player player = Bukkit.getPlayer(playerUUID);
+            String playerName = player != null ? player.getName() : playerUUID.toString();
+            Logs.logInfo("HackedServer | Sign probe response from " + playerName
+                    + ": [\"" + String.join("\", \"", lines) + "\"]");
+        }
+
+        Bukkit.getScheduler().runTask(HackedServerPlugin.get(), () -> {
+            if (!session.timedOut) {
+                restoreBlock(session);
+            }
+
+            Player onlinePlayer = Bukkit.getPlayer(playerUUID);
+            if (onlinePlayer == null || !onlinePlayer.isOnline()) {
+                return;
+            }
+
+            HackedPlayer hackedPlayer = HackedServer.getPlayer(playerUUID);
+            if (hackedPlayer == null) {
+                return;
+            }
+
+            for (int i = 0; i < session.lineChecks().size() && i < lines.length; i++) {
+                TranslationCheck check = session.lineChecks().get(i);
+                String response = lines[i] != null ? lines[i].trim() : "";
+                String expected = check.getExpectedVanillaResponse();
+
+                if (Config.DEBUG.toBool()) {
+                    Logs.logInfo("HackedServer | Probe line " + i + " (" + check.getName()
+                            + "): response=\"" + response + "\", expected=\"" + expected + "\"");
+                }
+
+                if (!response.isEmpty() && !response.equals(expected)) {
+                    if (Config.DEBUG.toBool()) {
+                        Logs.logInfo("HackedServer | DETECTED: " + check.getName()
+                                + " via sign translation probe");
+                    }
+                    String probeCheckId = "probe_" + check.getId();
+                    if (!hackedPlayer.hasGenericCheck(probeCheckId)) {
+                        hackedPlayer.addGenericCheck(probeCheckId);
+                        PayloadProcessor.runActions(onlinePlayer, check.getName(), check.getActions());
+                    }
+                }
+            }
+        });
     }
 
     private void restoreBlock(ProbeSession session) {
         try {
-            Location loc = session.signLocation;
-            if (loc.getWorld() != null && loc.isChunkLoaded()) {
-                loc.getBlock().setBlockData(session.originalBlockData, false);
-            }
+            Block block = session.signLocation().getBlock();
+            block.setBlockData(session.originalBlockData(), false);
         } catch (Throwable e) {
-            Logs.logWarning("Failed to restore block after probe: " + e.getMessage());
+            // Best effort
         }
     }
+
 }

--- a/hackedserver-spigot/src/main/java/org/hackedserver/spigot/probing/SignTranslationProber.java
+++ b/hackedserver-spigot/src/main/java/org/hackedserver/spigot/probing/SignTranslationProber.java
@@ -1,0 +1,227 @@
+package org.hackedserver.spigot.probing;
+
+import net.kyori.adventure.text.Component;
+import net.kyori.adventure.text.serializer.plain.PlainTextComponentSerializer;
+import org.bukkit.Bukkit;
+import org.bukkit.Location;
+import org.bukkit.Material;
+import org.bukkit.block.Block;
+import org.bukkit.block.BlockState;
+import org.bukkit.block.Sign;
+import org.bukkit.block.data.BlockData;
+import org.bukkit.block.sign.Side;
+import org.bukkit.block.sign.SignSide;
+import org.bukkit.entity.Player;
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.EventPriority;
+import org.bukkit.event.Listener;
+import org.bukkit.event.block.SignChangeEvent;
+import org.bukkit.event.player.PlayerJoinEvent;
+import org.bukkit.event.player.PlayerQuitEvent;
+import org.hackedserver.core.HackedPlayer;
+import org.hackedserver.core.HackedServer;
+import org.hackedserver.core.probing.ProbingConfig;
+import org.hackedserver.core.probing.TranslationCheck;
+import org.hackedserver.spigot.HackedServerPlugin;
+import org.hackedserver.spigot.listeners.PayloadProcessor;
+import org.hackedserver.spigot.utils.logs.Logs;
+
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+import java.util.concurrent.ConcurrentHashMap;
+
+/**
+ * Active probing via the sign translation vulnerability (MC-265322).
+ * <p>
+ * Places an invisible sign underground, writes translatable components on it,
+ * opens the sign editor for the player, and reads back the resolved text.
+ * If the client resolves a mod-specific translation key, the mod is detected.
+ * <p>
+ * Paper 1.20+ only (requires Sign API with Side support).
+ */
+public class SignTranslationProber implements Listener {
+
+    private static final PlainTextComponentSerializer PLAIN = PlainTextComponentSerializer.plainText();
+
+    /**
+     * Tracks active probes: player UUID → probe session data.
+     */
+    private final Map<UUID, ProbeSession> activeSessions = new ConcurrentHashMap<>();
+
+    /**
+     * Stores which checks are assigned to which sign line for each probe.
+     */
+    private record ProbeSession(Location signLocation, BlockData originalBlockData,
+                                List<TranslationCheck> lineChecks) {
+    }
+
+    @EventHandler(priority = EventPriority.MONITOR)
+    public void onPlayerJoin(PlayerJoinEvent event) {
+        if (!ProbingConfig.isEnabled()) {
+            return;
+        }
+
+        List<TranslationCheck> checks = ProbingConfig.getChecks();
+        if (checks.isEmpty()) {
+            return;
+        }
+
+        Player player = event.getPlayer();
+        if (player.hasPermission("hackedserver.bypass")) {
+            return;
+        }
+
+        // Schedule the probe after the configured delay
+        Bukkit.getScheduler().runTaskLater(HackedServerPlugin.get(), () -> {
+            if (!player.isOnline()) {
+                return;
+            }
+            startProbe(player, checks);
+        }, ProbingConfig.getDelayTicks());
+    }
+
+    @EventHandler
+    public void onPlayerQuit(PlayerQuitEvent event) {
+        ProbeSession session = activeSessions.remove(event.getPlayer().getUniqueId());
+        if (session != null) {
+            restoreBlock(session);
+        }
+    }
+
+    @EventHandler(priority = EventPriority.LOWEST)
+    public void onSignChange(SignChangeEvent event) {
+        Player player = event.getPlayer();
+        ProbeSession session = activeSessions.remove(player.getUniqueId());
+        if (session == null) {
+            return;
+        }
+
+        // Cancel the event so the sign is never actually updated in the world
+        event.setCancelled(true);
+
+        // Restore the original block
+        restoreBlock(session);
+
+        // Analyze responses
+        HackedPlayer hackedPlayer = HackedServer.getPlayer(player.getUniqueId());
+
+        for (int i = 0; i < session.lineChecks.size(); i++) {
+            TranslationCheck check = session.lineChecks.get(i);
+            Component lineComponent = event.line(i);
+            String response = PLAIN.serialize(lineComponent).trim();
+            String expected = check.getExpectedVanillaResponse();
+
+            // If the response differs from what vanilla would return, the mod resolved the key
+            if (!response.isEmpty() && !response.equals(expected)) {
+                String probeCheckId = "probe_" + check.getId();
+                if (!hackedPlayer.hasGenericCheck(probeCheckId)) {
+                    hackedPlayer.addGenericCheck(probeCheckId);
+                    PayloadProcessor.runActions(player, check.getName(), check.getActions());
+                }
+            }
+        }
+    }
+
+    private void startProbe(Player player, List<TranslationCheck> checks) {
+        // Only use up to 4 checks (4 sign lines)
+        List<TranslationCheck> lineChecks = checks.size() > 4 ? checks.subList(0, 4) : checks;
+
+        Location playerLoc = player.getLocation();
+        Location signLoc = playerLoc.clone().add(0, ProbingConfig.getSignOffsetY(), 0);
+
+        // Clamp Y to valid range
+        int minY = signLoc.getWorld().getMinHeight();
+        if (signLoc.getBlockY() < minY) {
+            signLoc.setY(minY);
+        }
+
+        Block block = signLoc.getBlock();
+        BlockData originalData = block.getBlockData();
+
+        try {
+            // Place sign block
+            block.setType(Material.OAK_SIGN, false);
+            BlockState state = block.getState();
+            if (!(state instanceof Sign sign)) {
+                // Shouldn't happen, but restore if it does
+                block.setBlockData(originalData, false);
+                return;
+            }
+
+            // Write translation checks on the back side (less visible)
+            Side side = Side.BACK;
+            SignSide signSide = sign.getSide(side);
+
+            for (int i = 0; i < lineChecks.size(); i++) {
+                TranslationCheck check = lineChecks.get(i);
+                Component component = buildTranslationComponent(check);
+                signSide.line(i, component);
+            }
+
+            sign.update(true, false);
+
+            // Store session
+            activeSessions.put(player.getUniqueId(),
+                    new ProbeSession(signLoc.clone(), originalData, lineChecks));
+
+            // Open sign editor after a short delay (client needs to receive block data first)
+            Bukkit.getScheduler().runTaskLater(HackedServerPlugin.get(), () -> {
+                if (!player.isOnline()) {
+                    ProbeSession s = activeSessions.remove(player.getUniqueId());
+                    if (s != null) restoreBlock(s);
+                    return;
+                }
+
+                try {
+                    player.openSign(sign, side);
+                } catch (Throwable e) {
+                    Logs.logWarning("Failed to open sign editor for probe: " + e.getMessage());
+                    ProbeSession s = activeSessions.remove(player.getUniqueId());
+                    if (s != null) restoreBlock(s);
+                    return;
+                }
+
+                // Schedule cleanup in case the client never responds
+                Bukkit.getScheduler().runTaskLater(HackedServerPlugin.get(), () -> {
+                    ProbeSession s = activeSessions.remove(player.getUniqueId());
+                    if (s != null) {
+                        restoreBlock(s);
+                    }
+                }, 100L); // 5 second timeout
+            }, 5L);
+
+        } catch (Throwable e) {
+            Logs.logWarning("Failed to start translation probe: " + e.getMessage());
+            block.setBlockData(originalData, false);
+        }
+    }
+
+    /**
+     * Builds the Adventure component for a translation check.
+     * <p>
+     * With bypass_protection: uses %s substitution to wrap the key,
+     * evading client-side mixins that strip known mod keys from signs.
+     * Without: uses a plain translatable component.
+     */
+    private Component buildTranslationComponent(TranslationCheck check) {
+        if (check.isBypassProtection()) {
+            // Wrap in %s to bypass sign translation protection mixins
+            // The outer key "%s" doesn't contain the mod name, so protection doesn't trigger
+            return Component.translatable("%s", Component.translatable(check.getTranslationKey()));
+        } else {
+            return Component.translatable(check.getTranslationKey());
+        }
+    }
+
+    private void restoreBlock(ProbeSession session) {
+        try {
+            Location loc = session.signLocation;
+            if (loc.getWorld() != null && loc.isChunkLoaded()) {
+                loc.getBlock().setBlockData(session.originalBlockData, false);
+            }
+        } catch (Throwable e) {
+            Logs.logWarning("Failed to restore block after probe: " + e.getMessage());
+        }
+    }
+}

--- a/hackedserver-spigot/src/main/java/org/hackedserver/spigot/protocol/PacketEventsIntegration.java
+++ b/hackedserver-spigot/src/main/java/org/hackedserver/spigot/protocol/PacketEventsIntegration.java
@@ -72,6 +72,14 @@ public final class PacketEventsIntegration {
         plugin.getLogger().info("PacketEvents listener registered successfully");
     }
 
+    public boolean isReadyForListeners() {
+        try {
+            return PacketEvents.getAPI() != null && PacketEvents.getAPI().getEventManager() != null;
+        } catch (Throwable ignored) {
+            return false;
+        }
+    }
+
     /**
      * Unregister the packet listener and terminate PacketEvents if we own it.
      */

--- a/hackedserver-spigot/src/main/java/org/hackedserver/spigot/utils/HackedInventoryView.java
+++ b/hackedserver-spigot/src/main/java/org/hackedserver/spigot/utils/HackedInventoryView.java
@@ -1,0 +1,153 @@
+package org.hackedserver.spigot.utils;
+
+import net.kyori.adventure.text.Component;
+import net.kyori.adventure.text.format.NamedTextColor;
+import net.kyori.adventure.text.format.TextDecoration;
+import net.kyori.adventure.text.serializer.legacy.LegacyComponentSerializer;
+import org.bukkit.Bukkit;
+import org.bukkit.Material;
+import org.bukkit.entity.Player;
+import org.bukkit.inventory.Inventory;
+import org.bukkit.inventory.ItemStack;
+import org.bukkit.inventory.meta.ItemMeta;
+import org.bukkit.inventory.meta.SkullMeta;
+import org.hackedserver.core.HackedPlayer;
+import org.hackedserver.core.HackedServer;
+import org.hackedserver.core.config.GenericCheck;
+import org.hackedserver.spigot.HackedHolder;
+
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.List;
+import java.util.stream.Collectors;
+
+public final class HackedInventoryView {
+
+    private static final int ITEMS_PER_PAGE = 45;
+    private static final int INV_SIZE = 54;
+    private static final int NAV_PREV_SLOT = 45;
+    private static final int NAV_INFO_SLOT = 49;
+    private static final int NAV_NEXT_SLOT = 53;
+
+    private HackedInventoryView() {
+    }
+
+    public static void openInvPage(Player viewer, int page) {
+        List<HackedPlayer> players = HackedServer.getPlayers().stream()
+                .sorted(Comparator.comparing(p -> {
+                    String name = Bukkit.getOfflinePlayer(p.getUuid()).getName();
+                    return name != null ? name.toLowerCase() : "";
+                }))
+                .collect(Collectors.toList());
+
+        int totalPages = Math.max(1, (int) Math.ceil((double) players.size() / ITEMS_PER_PAGE));
+        page = Math.max(0, Math.min(page, totalPages - 1));
+
+        HackedHolder holder = new HackedHolder(page);
+        Inventory inv = Bukkit.createInventory(holder, INV_SIZE, "HackedServer");
+        holder.setInventory(inv);
+
+        List<GenericCheck> loaderChecks = HackedServer.getChecks().stream()
+                .filter(c -> "loader".equals(c.getCategory()))
+                .sorted(Comparator.comparing(GenericCheck::getName))
+                .collect(Collectors.toList());
+
+        int start = page * ITEMS_PER_PAGE;
+        int end = Math.min(start + ITEMS_PER_PAGE, players.size());
+
+        for (int i = start; i < end; i++) {
+            HackedPlayer hackedPlayer = players.get(i);
+            ItemStack head = new ItemStack(Material.PLAYER_HEAD);
+            SkullMeta meta = (SkullMeta) head.getItemMeta();
+            assert meta != null;
+            meta.setOwningPlayer(Bukkit.getOfflinePlayer(hackedPlayer.getUuid()));
+
+            String playerName = Bukkit.getOfflinePlayer(hackedPlayer.getUuid()).getName();
+            if (playerName != null) {
+                meta.setDisplayName(toLegacy(Component.text(playerName, NamedTextColor.WHITE)
+                        .decoration(TextDecoration.ITALIC, false)));
+            }
+
+            List<String> lore = new ArrayList<>();
+
+            for (GenericCheck loader : loaderChecks) {
+                boolean detected = hackedPlayer.getGenericChecks().contains(loader.getId());
+                if (detected) {
+                    lore.add(toLegacy(Component.text("✓ " + loader.getName() + " detected", NamedTextColor.GREEN)
+                            .decoration(TextDecoration.ITALIC, false)));
+                } else {
+                    lore.add(toLegacy(Component.text("✗ " + loader.getName() + " not detected", NamedTextColor.GRAY)
+                            .decoration(TextDecoration.ITALIC, false)));
+                }
+            }
+
+            lore.add(toLegacy(Component.text("━━━━━━━━━━━━━━━━━━━━", NamedTextColor.DARK_GRAY)));
+
+            List<GenericCheck> detectedNonLoader = HackedServer.getChecks().stream()
+                    .filter(check -> hackedPlayer.getGenericChecks().contains(check.getId()))
+                    .filter(check -> !"loader".equals(check.getCategory()))
+                    .sorted(Comparator.comparing(GenericCheck::getName))
+                    .collect(Collectors.toList());
+
+            int totalNonLoader = (int) HackedServer.getChecks().stream()
+                    .filter(check -> !"loader".equals(check.getCategory()))
+                    .count();
+            int cleanCount = totalNonLoader - detectedNonLoader.size();
+
+            if (detectedNonLoader.isEmpty()) {
+                lore.add(toLegacy(Component.text("✓ " + cleanCount + " checks passed", NamedTextColor.GREEN)
+                        .decoration(TextDecoration.ITALIC, false)));
+            } else {
+                for (GenericCheck check : detectedNonLoader) {
+                    lore.add(toLegacy(Component.text("⚠ " + check.getName(), NamedTextColor.YELLOW)
+                            .decoration(TextDecoration.ITALIC, false)));
+                }
+                lore.add(toLegacy(Component.text("")));
+                lore.add(toLegacy(Component.text("✓ " + cleanCount + " other checks passed", NamedTextColor.GREEN)
+                        .decoration(TextDecoration.ITALIC, false)));
+            }
+
+            meta.setLore(lore);
+            head.setItemMeta(meta);
+            inv.setItem(i - start, head);
+        }
+
+        if (page > 0) {
+            ItemStack prev = new ItemStack(Material.ARROW);
+            ItemMeta prevMeta = prev.getItemMeta();
+            assert prevMeta != null;
+            prevMeta.setDisplayName(toLegacy(Component.text("← Previous Page", NamedTextColor.GOLD)
+                    .decoration(TextDecoration.ITALIC, false)));
+            prev.setItemMeta(prevMeta);
+            inv.setItem(NAV_PREV_SLOT, prev);
+        }
+
+        ItemStack info = new ItemStack(Material.PAPER);
+        ItemMeta infoMeta = info.getItemMeta();
+        assert infoMeta != null;
+        infoMeta.setDisplayName(toLegacy(Component.text("Page " + (page + 1) + "/" + totalPages, NamedTextColor.WHITE)
+                .decoration(TextDecoration.ITALIC, false)));
+        List<String> infoLore = new ArrayList<>();
+        infoLore.add(toLegacy(Component.text(players.size() + " players tracked", NamedTextColor.GRAY)
+                .decoration(TextDecoration.ITALIC, false)));
+        infoMeta.setLore(infoLore);
+        info.setItemMeta(infoMeta);
+        inv.setItem(NAV_INFO_SLOT, info);
+
+        if (page < totalPages - 1) {
+            ItemStack next = new ItemStack(Material.ARROW);
+            ItemMeta nextMeta = next.getItemMeta();
+            assert nextMeta != null;
+            nextMeta.setDisplayName(toLegacy(Component.text("Next Page →", NamedTextColor.GOLD)
+                    .decoration(TextDecoration.ITALIC, false)));
+            next.setItemMeta(nextMeta);
+            inv.setItem(NAV_NEXT_SLOT, next);
+        }
+
+        viewer.openInventory(inv);
+    }
+
+    private static String toLegacy(Component component) {
+        return LegacyComponentSerializer.legacySection().serialize(component);
+    }
+}

--- a/hackedserver-spigot/src/main/resources/plugin.yml
+++ b/hackedserver-spigot/src/main/resources/plugin.yml
@@ -4,3 +4,8 @@ version: ${projectVersion}
 author: Th0rgal
 softdepend: [ ViaVersion, ProtocolSupport, ProtocolLib, packetevents, Geyser-Spigot, Floodgate ]
 api-version: 1.18
+commands:
+  hackedserver:
+    description: HackedServer main command
+    aliases: [hs]
+    permission: hackedserver.command

--- a/hackedserver-velocity/src/main/java/org/hackedserver/velocity/HackedServerPlugin.java
+++ b/hackedserver-velocity/src/main/java/org/hackedserver/velocity/HackedServerPlugin.java
@@ -141,7 +141,7 @@ public class HackedServerPlugin {
                 continue;
             }
             if (player.hasPermission("hackedserver.bypass")) {
-                return;
+                continue;
             }
 
             for (String command : action.getConsoleCommands()) {

--- a/hackedserver-velocity/src/main/java/org/hackedserver/velocity/HackedServerPlugin.java
+++ b/hackedserver-velocity/src/main/java/org/hackedserver/velocity/HackedServerPlugin.java
@@ -37,7 +37,7 @@ import org.slf4j.Logger;
 @Plugin(
         id = "hackedserver",
         name = "HackedServer",
-        version = "3.16.0"
+        version = "3.17.2"
 )
 public class HackedServerPlugin {
 

--- a/hackedserver-velocity/src/main/java/org/hackedserver/velocity/HackedServerPlugin.java
+++ b/hackedserver-velocity/src/main/java/org/hackedserver/velocity/HackedServerPlugin.java
@@ -15,7 +15,9 @@ import com.velocitypowered.api.proxy.messages.MinecraftChannelIdentifier;
 import io.github.retrooper.packetevents.velocity.factory.VelocityPacketEventsBuilder;
 
 import org.hackedserver.core.bedrock.BedrockDetector;
+import org.hackedserver.core.config.Action;
 import org.hackedserver.core.config.ConfigsManager;
+import org.hackedserver.core.probing.PacketSignProber;
 import org.hackedserver.velocity.commands.HackedCommands;
 import org.hackedserver.velocity.listeners.CustomPayloadListener;
 import org.hackedserver.velocity.listeners.HackedPlayerListeners;
@@ -23,8 +25,13 @@ import org.hackedserver.velocity.logs.Logs;
 
 import com.google.inject.Inject;
 
+import net.kyori.adventure.text.minimessage.tag.resolver.Placeholder;
+import net.kyori.adventure.text.minimessage.tag.resolver.TagResolver;
+
 import java.io.File;
 import java.nio.file.Path;
+import java.util.List;
+import java.util.UUID;
 import org.slf4j.Logger;
 
 @Plugin(
@@ -37,6 +44,7 @@ public class HackedServerPlugin {
     private final ProxyServer server;
     private final HackedCommands commands;
     private final File folder;
+    private PacketSignProber signProber;
 
     @Inject
     public HackedServerPlugin(
@@ -60,9 +68,15 @@ public class HackedServerPlugin {
 
     @Subscribe
     public void onProxyInitialization(ProxyInitializeEvent event) {
-        server.getEventManager().register(this, new HackedPlayerListeners(server, this));
+        // Create sign prober with Velocity action executor
+        signProber = new PacketSignProber((uuid, playerName, checkName, actions) -> {
+            executeProbeActions(uuid, playerName, checkName, actions);
+        });
+
+        server.getEventManager().register(this, new HackedPlayerListeners(server, this, signProber));
         PacketEvents.getAPI().getEventManager().registerListener(
                 new CustomPayloadListener(server), PacketListenerPriority.NORMAL);
+        signProber.register();
         PacketEvents.getAPI().init();
         commands.create();
 
@@ -75,6 +89,11 @@ public class HackedServerPlugin {
         // Unregister all event listeners for this plugin
         server.getEventManager().unregisterListeners(this);
 
+        // Unregister sign prober before terminating PacketEvents
+        if (signProber != null) {
+            signProber.unregister();
+        }
+
         // Terminate and reinit PacketEvents
         PacketEvents.getAPI().terminate();
         PacketEvents.getAPI().init();
@@ -85,9 +104,56 @@ public class HackedServerPlugin {
         // Recreate commands
         commands.create();
 
+        // Re-create sign prober with fresh config
+        signProber = new PacketSignProber((uuid, playerName, checkName, actions) -> {
+            executeProbeActions(uuid, playerName, checkName, actions);
+        });
+
         // Re-register event listeners
-        server.getEventManager().register(this, new HackedPlayerListeners(server, this));
+        server.getEventManager().register(this, new HackedPlayerListeners(server, this, signProber));
         PacketEvents.getAPI().getEventManager().registerListener(
                 new CustomPayloadListener(server), PacketListenerPriority.NORMAL);
+        signProber.register();
+    }
+
+    private void executeProbeActions(UUID uuid, String playerName, String checkName, List<Action> actions) {
+        if (actions == null || actions.isEmpty()) {
+            return;
+        }
+
+        TagResolver.Single[] templates = new TagResolver.Single[]{
+                Placeholder.unparsed("player", playerName),
+                Placeholder.parsed("name", checkName)
+        };
+
+        for (Action action : actions) {
+            if (action.hasAlert()) {
+                Logs.logComponent(action.getAlert(templates));
+                for (com.velocitypowered.api.proxy.Player admin : server.getAllPlayers()) {
+                    if (admin.hasPermission("hackedserver.alert")) {
+                        admin.sendMessage(action.getAlert(templates));
+                    }
+                }
+            }
+
+            com.velocitypowered.api.proxy.Player player = server.getPlayer(uuid).orElse(null);
+            if (player == null || !player.isActive()) {
+                continue;
+            }
+            if (player.hasPermission("hackedserver.bypass")) {
+                return;
+            }
+
+            for (String command : action.getConsoleCommands()) {
+                server.getCommandManager().executeAsync(server.getConsoleCommandSource(),
+                        command.replace("<player>", playerName)
+                                .replace("<name>", checkName));
+            }
+            for (String command : action.getPlayerCommands()) {
+                server.getCommandManager().executeAsync(player,
+                        command.replace("<player>", playerName)
+                                .replace("<name>", checkName));
+            }
+        }
     }
 }

--- a/hackedserver-velocity/src/main/java/org/hackedserver/velocity/listeners/CustomPayloadListener.java
+++ b/hackedserver-velocity/src/main/java/org/hackedserver/velocity/listeners/CustomPayloadListener.java
@@ -108,6 +108,7 @@ public class CustomPayloadListener implements PacketListener {
     private void processForgePacket(Player player, HackedPlayer hackedPlayer, String channel, String message) {
         // Detect client type from minecraft:brand
         if (ForgeChannelParser.BRAND_CHANNEL.equalsIgnoreCase(channel)) {
+            hackedPlayer.setBrand(message);
             ForgeClientType clientType = ForgeChannelParser.parseClientType(message);
             if (clientType != null && hackedPlayer.getForgeClientType() == null) {
                 hackedPlayer.setForgeClientType(clientType);
@@ -125,6 +126,18 @@ public class CustomPayloadListener implements PacketListener {
                 ForgeHandshakeResult result = ForgeHandshakeProcessor.processMods(hackedPlayer, mods);
                 if (result.hasTriggers()) {
                     runForgeActions(result.getTriggers(), player.getUniqueId(), player.getUsername());
+                }
+            }
+
+            // Brand spoofing detection: vanilla brand + fabric channels = ServerSpoof
+            if (ForgeConfig.isSpoofingDetectionEnabled()
+                    && !hackedPlayer.hasGenericCheck("spoofed_brand")
+                    && ForgeChannelParser.isVanillaBrand(hackedPlayer.getBrand())
+                    && ForgeChannelParser.containsFabricChannels(message)) {
+                hackedPlayer.addGenericCheck("spoofed_brand");
+                List<Action> actions = ForgeConfig.getSpoofingActions();
+                if (!actions.isEmpty()) {
+                    runActions(actions, player.getUniqueId(), player.getUsername(), "Spoofed Brand (Fabric)");
                 }
             }
         }

--- a/hackedserver-velocity/src/main/java/org/hackedserver/velocity/listeners/CustomPayloadListener.java
+++ b/hackedserver-velocity/src/main/java/org/hackedserver/velocity/listeners/CustomPayloadListener.java
@@ -117,6 +117,9 @@ public class CustomPayloadListener implements PacketListener {
                     runForgeActions(result.getTriggers(), player.getUniqueId(), player.getUsername());
                 }
             }
+
+            // Re-evaluate spoofing: brand arrived after register
+            checkBrandSpoofing(player, hackedPlayer);
         }
 
         // Detect mods from minecraft:register
@@ -129,16 +132,25 @@ public class CustomPayloadListener implements PacketListener {
                 }
             }
 
+            // Track fabric channels for deferred spoofing check
+            if (ForgeChannelParser.containsFabricChannels(message)) {
+                hackedPlayer.setFabricChannelsDetected(true);
+            }
+
             // Brand spoofing detection: vanilla brand + fabric channels = ServerSpoof
-            if (ForgeConfig.isSpoofingDetectionEnabled()
-                    && !hackedPlayer.hasGenericCheck("spoofed_brand")
-                    && ForgeChannelParser.isVanillaBrand(hackedPlayer.getBrand())
-                    && ForgeChannelParser.containsFabricChannels(message)) {
-                hackedPlayer.addGenericCheck("spoofed_brand");
-                List<Action> actions = ForgeConfig.getSpoofingActions();
-                if (!actions.isEmpty()) {
-                    runActions(actions, player.getUniqueId(), player.getUsername(), "Spoofed Brand (Fabric)");
-                }
+            checkBrandSpoofing(player, hackedPlayer);
+        }
+    }
+
+    private void checkBrandSpoofing(Player player, HackedPlayer hackedPlayer) {
+        if (ForgeConfig.isSpoofingDetectionEnabled()
+                && !hackedPlayer.hasGenericCheck("spoofed_brand")
+                && ForgeChannelParser.isVanillaBrand(hackedPlayer.getBrand())
+                && hackedPlayer.hasFabricChannelsDetected()) {
+            hackedPlayer.addGenericCheck("spoofed_brand");
+            List<Action> actions = ForgeConfig.getSpoofingActions();
+            if (!actions.isEmpty()) {
+                runActions(actions, player.getUniqueId(), player.getUsername(), "Spoofed Brand (Fabric)");
             }
         }
     }

--- a/hackedserver-velocity/src/main/java/org/hackedserver/velocity/listeners/CustomPayloadListener.java
+++ b/hackedserver-velocity/src/main/java/org/hackedserver/velocity/listeners/CustomPayloadListener.java
@@ -23,6 +23,7 @@ import org.hackedserver.core.forge.ForgeConfig;
 import org.hackedserver.core.forge.ForgeHandshakeProcessor;
 import org.hackedserver.core.forge.ForgeHandshakeResult;
 import org.hackedserver.core.forge.ForgeModInfo;
+import org.hackedserver.core.forge.ForgeSpoofingDetector;
 import org.hackedserver.core.lunar.LunarActionTrigger;
 import org.hackedserver.core.lunar.LunarApolloHandshakeParser;
 import org.hackedserver.core.lunar.LunarHandshakeProcessor;
@@ -143,14 +144,10 @@ public class CustomPayloadListener implements PacketListener {
     }
 
     private void checkBrandSpoofing(Player player, HackedPlayer hackedPlayer) {
-        if (ForgeConfig.isSpoofingDetectionEnabled()
-                && !hackedPlayer.hasGenericCheck("spoofed_brand")
-                && ForgeChannelParser.isVanillaBrand(hackedPlayer.getBrand())
-                && hackedPlayer.hasFabricChannelsDetected()) {
-            hackedPlayer.addGenericCheck("spoofed_brand");
+        if (ForgeSpoofingDetector.detect(hackedPlayer)) {
             List<Action> actions = ForgeConfig.getSpoofingActions();
             if (!actions.isEmpty()) {
-                runActions(actions, player.getUniqueId(), player.getUsername(), "Spoofed Brand (Fabric)");
+                runActions(actions, player.getUniqueId(), player.getUsername(), ForgeSpoofingDetector.CHECK_NAME);
             }
         }
     }

--- a/hackedserver-velocity/src/main/java/org/hackedserver/velocity/listeners/HackedPlayerListeners.java
+++ b/hackedserver-velocity/src/main/java/org/hackedserver/velocity/listeners/HackedPlayerListeners.java
@@ -1,5 +1,7 @@
 package org.hackedserver.velocity.listeners;
 
+import com.github.retrooper.packetevents.PacketEvents;
+import com.github.retrooper.packetevents.protocol.player.User;
 import com.velocitypowered.api.event.Subscribe;
 import com.velocitypowered.api.event.connection.DisconnectEvent;
 import com.velocitypowered.api.event.connection.LoginEvent;
@@ -13,6 +15,7 @@ import org.hackedserver.core.HackedServer;
 import org.hackedserver.core.bedrock.BedrockDetector;
 import org.hackedserver.core.config.Action;
 import org.hackedserver.core.config.BedrockConfig;
+import org.hackedserver.core.probing.PacketSignProber;
 import org.hackedserver.velocity.logs.Logs;
 
 import org.hackedserver.core.utils.JoinWebhook;
@@ -25,10 +28,12 @@ public class HackedPlayerListeners {
 
     private final ProxyServer server;
     private final Object plugin;
+    private final PacketSignProber signProber;
 
-    public HackedPlayerListeners(ProxyServer server, Object plugin) {
+    public HackedPlayerListeners(ProxyServer server, Object plugin, PacketSignProber signProber) {
         this.server = server;
         this.plugin = plugin;
+        this.signProber = signProber;
     }
 
     @Subscribe
@@ -49,10 +54,21 @@ public class HackedPlayerListeners {
             hackedPlayer.executePendingActions();
         }
         handleBedrockDetection(player, hackedPlayer);
+
+        // Start sign translation probe if enabled
+        if (signProber != null && !player.hasPermission("hackedserver.bypass")) {
+            User user = PacketEvents.getAPI().getPlayerManager().getUser(player);
+            if (user != null) {
+                signProber.startProbe(user, player.getUsername());
+            }
+        }
     }
 
     @Subscribe
     public void onPlayerLeave(DisconnectEvent event) {
+        if (signProber != null) {
+            signProber.onPlayerDisconnect(event.getPlayer().getUniqueId());
+        }
         HackedServer.removePlayer(event.getPlayer().getUniqueId());
     }
 


### PR DESCRIPTION
## Summary

Addresses a support ticket where Meteor Client (Fabric hacked client) was not detected on plain Fabric, but was detected on Lunar Client (via Apollo protobuf mod list).

- **Brand spoofing detection**: Detects when a client claims "vanilla" brand but registers Fabric channels in `minecraft:register`. This catches Meteor Client's ServerSpoof module which hides the Fabric loader. Configurable in `forge.toml` under `[spoofing]`.
- **`meteor-client` added to forge.toml blacklist**: The actual Fabric mod ID is `meteor-client`, not just `meteor` (which was already listed).
- **Generic check for `meteor-client`**: Checks `minecraft:register` payload for `meteor-client` namespace as a defensive measure.
- **Brand tracking on HackedPlayer**: Stores the raw brand string for cross-packet analysis.

### Limitations

Meteor Client on plain Fabric does **not** register identifiable channels or modify its brand (unless ServerSpoof is enabled). Without Lunar Client's Apollo protocol, passive detection of the specific mod is fundamentally limited. The sign translation vulnerability (MC-265322) could be explored as a future active probing mechanism.

## Test plan

- [ ] Deploy to test Paper server
- [ ] Join with Meteor Client on Fabric (no ServerSpoof) → should detect as "Fabric" loader + any registered channel mods
- [ ] Join with Meteor Client + ServerSpoof (brand: vanilla) → should trigger "Spoofed Brand (Fabric)" alert
- [ ] Join with Lunar Client + Meteor → should still detect via Apollo handshake (existing behavior)
- [ ] Join with vanilla client → should NOT trigger spoofing detection
- [ ] Join with legitimate Fabric client (e.g., Sodium only) → should detect as Fabric but NOT as spoofed
- [ ] Verify on BungeeCord and Velocity platforms

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches packet interception and player-action execution across all supported platforms and adds an active probing mechanism that sends/cancels packets and (on Spigot) temporarily edits blocks, so regressions could impact joins or false-positive enforcement.
> 
> **Overview**
> Adds **new Fabric/Meteor detection paths** across Spigot, BungeeCord, and Velocity. This includes configurable brand spoofing detection ("vanilla" `minecraft:brand` + Fabric channels in `minecraft:register`), plus a new active *sign-translation probe* (MC-265322) driven by `probing.toml` that can trigger actions when translation keys resolve unexpectedly.
> 
> Integrates PacketEvents more deeply for proxy platforms (explicit dependency + Bungee `depends`), wires probe lifecycle into join/quit/disable/reload, and introduces a Bukkit command fallback (and inventory UI extraction to `HackedInventoryView`) when CommandAPI isn’t available. Config updates add `[spoofing]` to `forge.toml`, add `meteor-client` to blacklists and generic checks, and bump `pluginVersion` to `3.17.2`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1763dc8efc0c997cd2c1f08a05737c6717010a08. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->