### PR TITLE
Update Hopper to 1.4.2

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -117,7 +117,7 @@ project(":hackedserver-spigot") {
         implementation("net.kyori:adventure-platform-bukkit:4.3.0")
         implementation("org.bstats:bstats-bukkit:3.1.0")
         // Hopper - Runtime dependency loader for auto-downloading ProtocolLib or PacketEvents
-        implementation("md.thomas.hopper:hopper-bukkit:1.4.1")
+        implementation("md.thomas.hopper:hopper-bukkit:1.4.2")
     }
 }
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,7 +1,7 @@
 org.gradle.jvmargs=-Xmx2G
 org.gradle.parallel=true
 
-pluginVersion=3.17.1
+pluginVersion=3.17.2
 
 copyJar=true
 hacked_server_plugin_path=

--- a/hackedserver-velocity/src/main/java/org/hackedserver/velocity/HackedServerPlugin.java
+++ b/hackedserver-velocity/src/main/java/org/hackedserver/velocity/HackedServerPlugin.java
@@ -30,7 +30,7 @@ import org.slf4j.Logger;
 @Plugin(
         id = "hackedserver",
         name = "HackedServer",
-        version = "3.16.0"
+        version = "3.17.2"
 )
 public class HackedServerPlugin {
 


### PR DESCRIPTION
## Summary
- Update the shaded Bukkit Hopper dependency from 1.4.1 to 1.4.2.

## Validation
- `./gradlew clean shadowJar --no-daemon`
- `git diff --check`
- Paper 1.21.11 test with HackedServer + preinstalled ProtocolLib 5.4.0: both plugins initialized and the plugins folder stayed at only `HackedServer.jar` and `ProtocolLib-current.jar`.
- Paper 1.21.11 test with HackedServer + latest ProtocolLib GitHub Actions artifact (`5.5.0-SNAPSHOT`, created 2026-04-07): HackedServer did not recreate or force-install a separate `ProtocolLib.jar` while a ProtocolLib jar was already present. That artifact itself requires a newer Java runtime than Java 21, so it could not be used as the load-success test in this container.

## Reported ProtocolLib issue
This confirms HackedServer no longer forces an additional stale ProtocolLib jar when a server already has a ProtocolLib jar installed. Server owners who intentionally run a newer/dev ProtocolLib build can keep that jar in `plugins/`; HackedServer will not replace it or add a second `ProtocolLib.jar`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Includes a runtime dependency-loader upgrade (Hopper) that can affect how ProtocolLib/PacketEvents are discovered or downloaded at startup; version-only metadata bumps are low risk.
> 
> **Overview**
> Updates the Bukkit-shaded Hopper runtime dependency loader from `1.4.1` to `1.4.2`.
> 
> Bumps the project `pluginVersion` to `3.17.2` and aligns the Velocity plugin `@Plugin` version string to match.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 33b2af093a91a1f4631eca5b2be7f9fae57c2d29. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->